### PR TITLE
[ROCKETMQ-120] Provider a adapter for spring and spring-boot

### DIFF
--- a/spring-boot-starter-rocketmq/.gitignore
+++ b/spring-boot-starter-rocketmq/.gitignore
@@ -1,0 +1,6 @@
+# Created by .ignore support plugin (hsz.mobi)
+*~
+.DS_Store
+*.iml
+target
+.idea/

--- a/spring-boot-starter-rocketmq/.travis.yml
+++ b/spring-boot-starter-rocketmq/.travis.yml
@@ -1,0 +1,13 @@
+notifications:
+  email:
+    recipients:
+      - angus.aqlu@gmail.com
+  on_success: change
+  on_failure: always
+
+language: java
+
+sudo: false
+
+jdk:
+  - oraclejdk8

--- a/spring-boot-starter-rocketmq/.travis.yml
+++ b/spring-boot-starter-rocketmq/.travis.yml
@@ -1,6 +1,7 @@
 notifications:
   email:
     recipients:
+      - dev@rocketmq.apache.org
       - angus.aqlu@gmail.com
   on_success: change
   on_failure: always

--- a/spring-boot-starter-rocketmq/.travis.yml
+++ b/spring-boot-starter-rocketmq/.travis.yml
@@ -2,7 +2,6 @@ notifications:
   email:
     recipients:
       - dev@rocketmq.apache.org
-      - angus.aqlu@gmail.com
   on_success: change
   on_failure: always
 

--- a/spring-boot-starter-rocketmq/LICENSE
+++ b/spring-boot-starter-rocketmq/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/spring-boot-starter-rocketmq/README.md
+++ b/spring-boot-starter-rocketmq/README.md
@@ -1,0 +1,207 @@
+# spring-boot-starter-rocketmq
+
+[中文](./README_zh_CN.md)
+
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
+
+Help developers quickly integrate [RocketMQ](http://rocketmq.apache.org/) in [Spring Boot](http://projects.spring.io/spring-boot/). Support the Spring Message specification to facilitate developers to quickly switch from other MQ to RocketMQ.
+
+
+Features:
+
+- [x] synchronous transmission
+- [x] synchronous ordered transmission
+- [x] asynchronous transmission
+- [x] asynchronous ordered transmission
+- [x] orderly consume
+- [x] concurrently consume(broadcasting/clustering)
+- [x] One-way transmission
+- [ ] transaction transmission
+- [ ] Pull consume 
+
+## Quick Start
+
+```xml
+<!--add dependency in pom.xml-->
+<dependency>
+    <groupId>org.apache.rocketmq</groupId>
+    <artifactId>spring-boot-starter-rocketmq</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+</dependency>
+```
+
+> Info:
+>
+> if this version not exists in maven central repository, you can use `mvn clean install` build it by self. If you want use a release version, please see another project: [https://github.com/QianmiOpen/spring-boot-starter-rocketmq](https://github.com/QianmiOpen/spring-boot-starter-rocketmq)
+
+### Produce Message
+
+```properties
+## application.properties
+spring.rocketmq.name-server=172.19.0.1:9876
+spring.rocketmq.producer.group=my-group
+```
+
+```java
+@SpringBootApplication
+public class ProducerApplication implements CommandLineRunner{
+    @Resource
+    private RocketMQTemplate rocketMQTemplate;
+    
+    public static void main(String[] args){
+        SpringApplication.run(ProducerApplication.class, args);
+    }
+    
+    public void run(String... args) throws Exception {
+        rocketMQTemplate.convertAndSend("test-topic-1", "Hello, World!");
+        rocketMQTemplate.send("test-topic-1", MessageBuilder.withPayload("Hello, World! I'm from spring message").build());
+        rocketMQTemplate.convertAndSend("test-topic-2", new OrderPaidEvent("T_001", new BigDecimal("88.00")));
+        
+//        rocketMQTemplate.destroy(); // notes:  once rocketMQTemplate be destroyed, you can not send any message again with this rocketMQTemplate
+    }
+    
+    @Data
+    @AllArgsConstructor
+    public class OrderPaidEvent implements Serializable{
+        private String orderId;
+        
+        private BigDecimal paidMoney;
+    }
+}
+```
+
+> More relevant configurations for produce:
+>
+> ```properties
+> spring.rocketmq.producer.retry-times-when-send-async-failed=0
+> spring.rocketmq.producer.send-msg-timeout=300000
+> spring.rocketmq.producer.compress-msg-body-over-howmuch=4096
+> spring.rocketmq.producer.max-message-size=4194304
+> spring.rocketmq.producer.retry-another-broker-when-not-store-ok=false
+> spring.rocketmq.producer.retry-times-when-send-failed=2
+> ```
+
+### Consume Message
+
+```properties
+## application.properties
+spring.rocketmq.name-server=172.19.0.1:9876
+```
+
+```java
+@SpringBootApplication
+public class ConsumerApplication{
+    
+    public static void main(String[] args){
+        SpringApplication.run(ConsumerApplication.class, args);
+    }
+    
+    @Slf4j
+    @Service
+    @RocketMQMessageListener(topic = "test-topic-1", consumerGroup = "my-consumer_test-topic-1")
+    public class MyConsumer1 implements RocketMQListener<String>{
+        public void onMessage(String message) {
+            log.info("received message: {}", message);
+        }
+    }
+    
+    @Slf4j
+    @Service
+    @RocketMQMessageListener(topic = "test-topic-2", consumerGroup = "my-consumer_test-topic-2")
+    public class MyConsumer2 implements RocketMQListener<OrderPaidEvent>{
+        public void onMessage(OrderPaidEvent orderPaidEvent) {
+            log.info("received orderPaidEvent: {}", orderPaidEvent);
+        }
+    }
+}
+```
+
+
+> More relevant configurations for consume:
+>
+> see: [RocketMQMessageListener](src/main/java/org/apache/rocketmq/spring/starter/annotation/RocketMQMessageListener.java) 
+
+
+## FAQ
+
+1. How to connected many `nameserver` on production environment？
+
+    `spring.rocketmq.name-server` support the configuration of multiple `nameserver`, separated by `;`. For example: `172.19.0.1: 9876; 172.19.0.2: 9876`
+
+1. When was `rocketMQTemplate` destroyed?
+
+    Developers do not need to manually execute the `rocketMQTemplate.destroy ()` method when using `rocketMQTemplate` to send a message in the project, and` rocketMQTemplate` will be destroyed automatically when the spring container is destroyed.
+
+1. start exception：`Caused by: org.apache.rocketmq.client.exception.MQClientException: The consumer group[xxx] has been created before, specify another name please`
+
+   RocketMQ in the design do not want a consumer to deal with multiple types of messages at the same time, so the same `consumerGroup` consumer responsibility should be the same, do not do different things (that is, consumption of multiple topics). Suggested `consumerGroup` and` topic` one correspondence.
+    
+1. How is the message content body being serialized and deserialized?
+
+    RocketMQ's message body is stored as `byte []`. When the business system message content body if it is `java.lang.String` type, unified in accordance with` utf-8` code into `byte []`; If the business system message content is not `java.lang.String` Type, then use [jackson-databind](https://github.com/FasterXML/jackson-databind) serialized into the `JSON` format string, and then unified in accordance with` utf-8` code into `byte [] `.
+    
+1. How do I specify the `tags` for topic?
+
+    RocketMQ best practice recommended: an application as much as possible with one Topic, the message sub-type with `tags` to identify,` tags` can be set by the application free.
+    
+    When you use `rocketMQTemplate` to send a message, set the destination of the message by setting the` destination` parameter of the send method. The `destination` format is `topicName:tagName`, `:` Precedes the name of the topic, followed by the `tags` name.
+    
+    > Note:
+    >
+    > `tags` looks a complex, but when sending a message , the destination can only specify one topic under a `tag`, can not specify multiple.
+    
+1. How do I set the message's `key` when sending a message?
+
+    You can send a message by overloading method like `xxxSend(String destination, Message<?> msg, ...)`, setting `headers` of `msg`. for example:
+    
+    ```java
+    Message<?> message = MessageBuilder.withPayload(payload).setHeader(MessageConst.PROPERTY_KEYS, msgId).build();
+    rocketMQTemplate.send("topic-test", message);
+    ```
+
+    Similarly, you can also set the message `FLAG`,` WAIT_STORE_MSG_OK` and some other user-defined other header information according to the above method.
+    
+    > Note:
+    >
+    > In the case of converting Spring's Message to RocketMQ's Message, to prevent the `header` information from conflicting with RocketMQ's system properties, the prefix `USERS_` was added in front of all `header` names. So if you want to get a custom message header when consuming, please pass through the key at the beginning of `USERS_` in the header.
+    
+1. When consume message, in addition to get the message `payload`, but also want to get RocketMQ message of other system attributes, how to do?
+
+    Consumers in the realization of `RocketMQListener` interface, only need to be generic for the` MessageExt` can, so in the `onMessage` method will receive RocketMQ native 'MessageExt` message.
+    
+    ```java
+    @Slf4j
+    @Service
+    @RocketMQMessageListener(topic = "test-topic-1", consumerGroup = "my-consumer_test-topic-1")
+    public class MyConsumer2 implements RocketMQListener<MessageExt>{
+        public void onMessage(MessageExt messageExt) {
+            log.info("received messageExt: {}", messageExt);
+        }
+    }
+    ```
+    
+1. How do I specify where consumers start consuming messages?
+
+    The default consume offset please refer: [RocketMQ FAQ](http://rocketmq.apache.org/docs/faq/).
+    To customize the consumer's starting location, simply add a `RocketMQPushConsumerLifecycleListener` interface implementation to the consumer class. Examples are as follows:
+    
+    ```java
+    @Slf4j
+    @Service
+    @RocketMQMessageListener(topic = "test-topic-1", consumerGroup = "my-consumer_test-topic-1")
+    public class MyConsumer1 implements RocketMQListener<String>, RocketMQPushConsumerLifecycleListener {
+        @Override
+        public void onMessage(String message) {
+            log.info("received message: {}", message);
+        }
+    
+        @Override
+        public void prepareStart(final DefaultMQPushConsumer consumer) {
+            // set consumer consume message from now
+            consumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_TIMESTAMP);
+            consumer.setConsumeTimestamp(UtilAll.timeMillisToHumanString3(System.currentTimeMillis()));
+        }
+    }
+    ```
+    
+    Similarly, any other configuration on `DefaultMQPushConsumer` can be done in the same way as above.

--- a/spring-boot-starter-rocketmq/README.md
+++ b/spring-boot-starter-rocketmq/README.md
@@ -21,6 +21,8 @@ Features:
 
 ## Quick Start
 
+Here are some key points listed, the complete example, please refer to: [rocketmq-demo](https://github.com/aqlu/rocketmq-demo)
+
 ```xml
 <!--add dependency in pom.xml-->
 <dependency>
@@ -85,8 +87,12 @@ public class ProducerApplication implements CommandLineRunner{
 
 ```properties
 ## application.properties
-spring.rocketmq.name-server=172.19.0.1:9876
+spring.rocketmq.name-server=127.0.0.1:9876
 ```
+
+> Note:
+> 
+> Maybe you need change `127.0.0.1:9876` with your real NameServer address for RocketMQ
 
 ```java
 @SpringBootApplication

--- a/spring-boot-starter-rocketmq/README.md
+++ b/spring-boot-starter-rocketmq/README.md
@@ -30,17 +30,17 @@ Features:
 </dependency>
 ```
 
-> Info:
->
-> if this version not exists in maven central repository, you can use `mvn clean install` build it by self. If you want use a release version, please see another project: [https://github.com/QianmiOpen/spring-boot-starter-rocketmq](https://github.com/QianmiOpen/spring-boot-starter-rocketmq)
-
 ### Produce Message
 
 ```properties
 ## application.properties
-spring.rocketmq.name-server=172.19.0.1:9876
+spring.rocketmq.name-server=127.0.0.1:9876
 spring.rocketmq.producer.group=my-group
 ```
+
+> Note:
+> 
+> Maybe you need change `127.0.0.1:9876` with your real NameServer address for RocketMQ
 
 ```java
 @SpringBootApplication

--- a/spring-boot-starter-rocketmq/README_zh_CN.md
+++ b/spring-boot-starter-rocketmq/README_zh_CN.md
@@ -30,17 +30,17 @@
 </dependency>
 ```
 
-> 备注:
->
-> 如果对应的版本在中央仓库不存在，你可以使用`mvn clean install`来自行构建。如果你希望使用正式的发布版本，你可以参考另外一个项目: [https://github.com/QianmiOpen/spring-boot-starter-rocketmq](https://github.com/QianmiOpen/spring-boot-starter-rocketmq)
-
 ### 发送消息
 
 ```properties
 ## application.properties
-spring.rocketmq.name-server=172.19.0.1:9876
+spring.rocketmq.name-server=127.0.0.1:9876
 spring.rocketmq.producer.group=my-group
 ```
+
+> 注意:
+> 
+> 请将上述示例配置中的`127.0.0.1:9876`替换成真实RocketMQ的NameServer地址与端口
 
 ```java
 @SpringBootApplication

--- a/spring-boot-starter-rocketmq/README_zh_CN.md
+++ b/spring-boot-starter-rocketmq/README_zh_CN.md
@@ -21,6 +21,8 @@
 
 ## Quick Start
 
+下面列出来了一些关键点，完整的示例请参考：[rocketmq-demo](https://github.com/aqlu/rocketmq-demo)
+
 ```xml
 <!--在pom.xml中添加依赖-->
 <dependency>
@@ -85,8 +87,12 @@ public class ProducerApplication implements CommandLineRunner{
 
 ```properties
 ## application.properties
-spring.rocketmq.name-server=172.19.0.1:9876
+spring.rocketmq.name-server=127.0.0.1:9876
 ```
+
+> 注意:
+> 
+> 请将上述示例配置中的`127.0.0.1:9876`替换成真实RocketMQ的NameServer地址与端口
 
 ```java
 @SpringBootApplication

--- a/spring-boot-starter-rocketmq/README_zh_CN.md
+++ b/spring-boot-starter-rocketmq/README_zh_CN.md
@@ -1,0 +1,206 @@
+# spring-boot-starter-rocketmq
+
+[English](./README.md)
+
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
+
+帮助开发者在[Spring Boot](http://projects.spring.io/spring-boot/)中快速集成[RocketMQ](http://rocketmq.apache.org/)。支持Spring Message规范，方便开发者从其它MQ快速切换到RocketMQ。
+
+
+功能特性：
+
+- [x] 同步发送
+- [x] 同步顺序发送
+- [x] 异步发送
+- [x] 异步顺序发送
+- [x] 顺序消费
+- [x] 并发消费（广播/集群）
+- [x] One-way方式发送
+- [ ] 事务方式发送
+- [ ] Pull消费 
+
+## Quick Start
+
+```xml
+<!--在pom.xml中添加依赖-->
+<dependency>
+    <groupId>org.apache.rocketmq</groupId>
+    <artifactId>spring-boot-starter-rocketmq</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+</dependency>
+```
+
+> 备注:
+>
+> 如果对应的版本在中央仓库不存在，你可以使用`mvn clean install`来自行构建。如果你希望使用正式的发布版本，你可以参考另外一个项目: [https://github.com/QianmiOpen/spring-boot-starter-rocketmq](https://github.com/QianmiOpen/spring-boot-starter-rocketmq)
+
+### 发送消息
+
+```properties
+## application.properties
+spring.rocketmq.name-server=172.19.0.1:9876
+spring.rocketmq.producer.group=my-group
+```
+
+```java
+@SpringBootApplication
+public class ProducerApplication implements CommandLineRunner{
+    @Resource
+    private RocketMQTemplate rocketMQTemplate;
+    
+    public static void main(String[] args){
+        SpringApplication.run(ProducerApplication.class, args);
+    }
+    
+    public void run(String... args) throws Exception {
+        rocketMQTemplate.convertAndSend("test-topic-1", "Hello, World!");
+        rocketMQTemplate.send("test-topic-1", MessageBuilder.withPayload("Hello, World! I'm from spring message").build());
+        rocketMQTemplate.convertAndSend("test-topic-2", new OrderPaidEvent("T_001", new BigDecimal("88.00")));
+        
+//        rocketMQTemplate.destroy(); // notes:  once rocketMQTemplate be destroyed, you can not send any message again with this rocketMQTemplate
+    }
+    
+    @Data
+    @AllArgsConstructor
+    public class OrderPaidEvent implements Serializable{
+        private String orderId;
+        
+        private BigDecimal paidMoney;
+    }
+}
+```
+
+> 更多发送相关配置
+>
+> ```properties
+> spring.rocketmq.producer.retry-times-when-send-async-failed=0
+> spring.rocketmq.producer.send-msg-timeout=300000
+> spring.rocketmq.producer.compress-msg-body-over-howmuch=4096
+> spring.rocketmq.producer.max-message-size=4194304
+> spring.rocketmq.producer.retry-another-broker-when-not-store-ok=false
+> spring.rocketmq.producer.retry-times-when-send-failed=2
+> ```
+
+### 接收消息
+
+```properties
+## application.properties
+spring.rocketmq.name-server=172.19.0.1:9876
+```
+
+```java
+@SpringBootApplication
+public class ConsumerApplication{
+    
+    public static void main(String[] args){
+        SpringApplication.run(ConsumerApplication.class, args);
+    }
+    
+    @Slf4j
+    @Service
+    @RocketMQMessageListener(topic = "test-topic-1", consumerGroup = "my-consumer_test-topic-1")
+    public class MyConsumer1 implements RocketMQListener<String>{
+        public void onMessage(String message) {
+            log.info("received message: {}", message);
+        }
+    }
+    
+    @Slf4j
+    @Service
+    @RocketMQMessageListener(topic = "test-topic-2", consumerGroup = "my-consumer_test-topic-2")
+    public class MyConsumer2 implements RocketMQListener<OrderPaidEvent>{
+        public void onMessage(OrderPaidEvent orderPaidEvent) {
+            log.info("received orderPaidEvent: {}", orderPaidEvent);
+        }
+    }
+}
+```
+
+
+> 更多消费相关配置
+>
+> see: [RocketMQMessageListener](src/main/java/org/apache/rocketmq/spring/starter/annotation/RocketMQMessageListener.java) 
+
+
+## FAQ
+
+1. 生产环境有多个`nameserver`该如何连接？
+
+   `spring.rocketmq.name-server`支持配置多个`nameserver`地址，采用`;`分隔即可。例如：`172.19.0.1:9876;172.19.0.2:9876`
+
+1. `rocketMQTemplate`在什么时候被销毁？
+
+    开发者在项目中使用`rocketMQTemplate`发送消息时，不需要手动执行`rocketMQTemplate.destroy()`方法， `rocketMQTemplate`会在spring容器销毁时自动销毁。
+
+1. 启动报错：`Caused by: org.apache.rocketmq.client.exception.MQClientException: The consumer group[xxx] has been created before, specify another name please`
+
+    RocketMQ在设计时就不希望一个消费者同时处理多个类型的消息，因此同一个`consumerGroup`下的consumer职责应该是一样的，不要干不同的事情（即消费多个topic）。建议`consumerGroup`与`topic`一一对应。
+    
+1. 发送的消息内容体是如何被序列化与反序列化的？
+
+    RocketMQ的消息体都是以`byte[]`方式存储。当业务系统的消息内容体如果是`java.lang.String`类型时，统一按照`utf-8`编码转成`byte[]`；如果业务系统的消息内容为非`java.lang.String`类型，则采用[jackson-databind](https://github.com/FasterXML/jackson-databind)序列化成`JSON`格式的字符串之后，再统一按照`utf-8`编码转成`byte[]`。
+    
+1. 如何指定topic的`tags`?
+
+    RocketMQ的最佳实践中推荐：一个应用尽可能用一个Topic，消息子类型用`tags`来标识，`tags`可以由应用自由设置。
+    在使用`rocketMQTemplate`发送消息时，通过设置发送方法的`destination`参数来设置消息的目的地，`destination`的格式为`topicName:tagName`，`:`前面表示topic的名称，后面表示`tags`名称。
+    
+    > 注意:
+    >
+    > `tags`从命名来看像是一个复数，但发送消息时，目的地只能指定一个topic下的一个`tag`，不能指定多个。
+    
+1. 发送消息时如何设置消息的`key`?
+
+    可以通过重载的`xxxSend(String destination, Message<?> msg, ...)`方法来发送消息，指定`msg`的`headers`来完成。示例：
+    
+    ```java
+    Message<?> message = MessageBuilder.withPayload(payload).setHeader(MessageConst.PROPERTY_KEYS, msgId).build();
+    rocketMQTemplate.send("topic-test", message);
+    ```
+
+    同理还可以根据上面的方式来设置消息的`FLAG`、`WAIT_STORE_MSG_OK`以及一些用户自定义的其它头信息。
+    
+    > 注意:
+    >
+    > 在将Spring的Message转化为RocketMQ的Message时，为防止`header`信息与RocketMQ的系统属性冲突，在所有`header`的名称前面都统一添加了前缀`USERS_`。因此在消费时如果想获取自定义的消息头信息，请遍历头信息中以`USERS_`开头的key即可。
+    
+1. 消费消息时，除了获取消息`payload`外，还想获取RocketMQ消息的其它系统属性，需要怎么做？
+
+    消费者在实现`RocketMQListener`接口时，只需要起泛型为`MessageExt`即可，这样在`onMessage`方法将接收到RocketMQ原生的`MessageExt`消息。
+    
+    ```java
+    @Slf4j
+    @Service
+    @RocketMQMessageListener(topic = "test-topic-1", consumerGroup = "my-consumer_test-topic-1")
+    public class MyConsumer2 implements RocketMQListener<MessageExt>{
+        public void onMessage(MessageExt messageExt) {
+            log.info("received messageExt: {}", messageExt);
+        }
+    }
+    ```
+    
+1. 如何指定消费者从哪开始消费消息，或开始消费的位置？
+
+    消费者默认开始消费的位置请参考：[RocketMQ FAQ](http://rocketmq.apache.org/docs/faq/)。
+    若想自定义消费者开始的消费位置，只需在消费者类添加一个`RocketMQPushConsumerLifecycleListener`接口的实现即可。 示例如下：
+    
+    ```java
+    @Slf4j
+    @Service
+    @RocketMQMessageListener(topic = "test-topic-1", consumerGroup = "my-consumer_test-topic-1")
+    public class MyConsumer1 implements RocketMQListener<String>, RocketMQPushConsumerLifecycleListener {
+        @Override
+        public void onMessage(String message) {
+            log.info("received message: {}", message);
+        }
+    
+        @Override
+        public void prepareStart(final DefaultMQPushConsumer consumer) {
+            // set consumer consume message from now
+            consumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_TIMESTAMP);
+            consumer.setConsumeTimestamp(UtilAll.timeMillisToHumanString3(System.currentTimeMillis()));
+        }
+    }
+    ```
+    
+    同理，任何关于`DefaultMQPushConsumer`的更多其它其它配置，都可以采用上述方式来完成。

--- a/spring-boot-starter-rocketmq/pom.xml
+++ b/spring-boot-starter-rocketmq/pom.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.5.7.RELEASE</version>
+    </parent>
+
+    <groupId>org.apache.rocketmq</groupId>
+    <artifactId>spring-boot-starter-rocketmq</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <name>Spring Boot Rocket Starter</name>
+    <description>Starter for messaging using Apache RocketMQ</description>
+
+    <organization>
+        <name>Apache Software Foundation</name>
+        <url>http://www.apache.org</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+
+    <properties>
+        <rocketmq-version>4.1.0-incubating</rocketmq-version>
+        <java.version>1.8</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rocketmq</groupId>
+            <artifactId>rocketmq-client</artifactId>
+            <version>${rocketmq-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-messaging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.2</version>
+                <configuration>
+                    <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <developers>
+        <developer>
+            <name>angus.aqlu</name>
+            <email>angus.aqlu@gmail.com</email>
+            <organization>Jiangsu QianMi Network Technology Co., Ltd.</organization>
+            <organizationUrl>http://www.qianmi.com</organizationUrl>
+        </developer>
+    </developers>
+
+    <profiles>
+        <profile>
+            <id>release-sign-artifacts</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.4</version>
+                        <configuration>
+                            <passphrase>${gpg.passphrase}</passphrase>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/spring-boot-starter-rocketmq/pom.xml
+++ b/spring-boot-starter-rocketmq/pom.xml
@@ -20,18 +20,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.7.RELEASE</version>
-    </parent>
-
     <groupId>org.apache.rocketmq</groupId>
     <artifactId>spring-boot-starter-rocketmq</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
     <name>Spring Boot Rocket Starter</name>
     <description>Starter for messaging using Apache RocketMQ</description>
+    <url>https://github.com/apache/rocketmq-externals/tree/master/spring-boot-starter-rocketmq</url>
 
     <organization>
         <name>Apache Software Foundation</name>
@@ -48,8 +43,16 @@
     </licenses>
 
     <properties>
-        <rocketmq-version>4.1.0-incubating</rocketmq-version>
+        <spring.boot.version>1.5.9.RELEASE</spring.boot.version>
+        <rocketmq-version>4.2.0</rocketmq-version>
         <java.version>1.8</java.version>
+
+        <resource.delimiter>@</resource.delimiter> <!-- delimiter that doesn't clash with Spring ${} placeholders -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <additionalparam>-Xdoclint:none</additionalparam>
     </properties>
     <dependencies>
         <dependency>
@@ -81,7 +84,6 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
@@ -96,6 +98,18 @@
         </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>
@@ -105,10 +119,6 @@
                 <configuration>
                     <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
@@ -51,6 +51,8 @@ import org.springframework.core.annotation.Order;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.util.Assert;
 
+import static org.apache.rocketmq.spring.starter.core.DefaultRocketMQListenerContainerConstants.*;
+
 @Configuration
 @EnableConfigurationProperties(RocketMQProperties.class)
 @ConditionalOnClass(MQClientAPIImpl.class)
@@ -154,20 +156,20 @@ public class RocketMQAutoConfiguration {
             RocketMQListener rocketMQListener = (RocketMQListener) bean;
             RocketMQMessageListener annotation = clazz.getAnnotation(RocketMQMessageListener.class);
             BeanDefinitionBuilder beanBuilder = BeanDefinitionBuilder.rootBeanDefinition(DefaultRocketMQListenerContainer.class);
-            beanBuilder.addPropertyValue("nameServer", rocketMQProperties.getNameServer());
-            beanBuilder.addPropertyValue("topic", environment.resolvePlaceholders(annotation.topic()));
+            beanBuilder.addPropertyValue(PROP_NAMESERVER, rocketMQProperties.getNameServer());
+            beanBuilder.addPropertyValue(PROP_TOPIC, environment.resolvePlaceholders(annotation.topic()));
 
-            beanBuilder.addPropertyValue("consumerGroup", environment.resolvePlaceholders(annotation.consumerGroup()));
-            beanBuilder.addPropertyValue("consumeMode", annotation.consumeMode());
-            beanBuilder.addPropertyValue("consumeThreadMax", annotation.consumeThreadMax());
-            beanBuilder.addPropertyValue("messageModel", annotation.messageModel());
-            beanBuilder.addPropertyValue("selectorExpress", environment.resolvePlaceholders(annotation.selectorExpress()));
-            beanBuilder.addPropertyValue("selectorType", annotation.selectorType());
-            beanBuilder.addPropertyValue("rocketMQListener", rocketMQListener);
+            beanBuilder.addPropertyValue(PROP_CONSUMER_GROUP, environment.resolvePlaceholders(annotation.consumerGroup()));
+            beanBuilder.addPropertyValue(PROP_CONSUME_MODE, annotation.consumeMode());
+            beanBuilder.addPropertyValue(PROP_CONSUME_THREAD_MAX, annotation.consumeThreadMax());
+            beanBuilder.addPropertyValue(PROP_MESSAGE_MODEL, annotation.messageModel());
+            beanBuilder.addPropertyValue(PROP_SELECTOR_EXPRESS, environment.resolvePlaceholders(annotation.selectorExpress()));
+            beanBuilder.addPropertyValue(PROP_SELECTOR_TYPE, annotation.selectorType());
+            beanBuilder.addPropertyValue(PROP_ROCKETMQ_LISTENER, rocketMQListener);
             if (Objects.nonNull(objectMapper)) {
-                beanBuilder.addPropertyValue("objectMapper", objectMapper);
+                beanBuilder.addPropertyValue(PROP_OBJECT_MAPPER, objectMapper);
             }
-            beanBuilder.setDestroyMethodName("destroy");
+            beanBuilder.setDestroyMethodName(METHOD_DESTROY);
 
             String containerBeanName = String.format("%s_%s", DefaultRocketMQListenerContainer.class.getName(), counter.incrementAndGet());
             DefaultListableBeanFactory beanFactory = (DefaultListableBeanFactory) applicationContext.getBeanFactory();

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
@@ -138,7 +138,7 @@ public class RocketMQAutoConfiguration {
         }
 
         @Override
-        public void afterPropertiesSet() throws Exception {
+        public void afterPropertiesSet() {
             Map<String, Object> beans = this.applicationContext.getBeansWithAnnotation(RocketMQMessageListener.class);
 
             if (Objects.nonNull(beans)) {

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.spring.starter.annotation.RocketMQMessageListener;
+import org.apache.rocketmq.spring.starter.core.DefaultRocketMQListenerContainer;
+import org.apache.rocketmq.spring.starter.core.RocketMQListener;
+import org.apache.rocketmq.spring.starter.core.RocketMQTemplate;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Resource;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.impl.MQClientAPIImpl;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.Assert;
+
+/**
+ * RocketMqAutoConfiguration Created by aqlu on 2017/9/27.
+ */
+@Configuration
+@EnableConfigurationProperties(RocketMQProperties.class)
+@ConditionalOnClass(MQClientAPIImpl.class)
+@Order
+@Slf4j
+public class RocketMQAutoConfiguration {
+
+    @Bean
+    @ConditionalOnClass(DefaultMQProducer.class)
+    @ConditionalOnMissingBean(DefaultMQProducer.class)
+    @ConditionalOnProperty(prefix = "spring.rocketmq", value = {"nameServer", "producer.group"})
+    public DefaultMQProducer mqProducer(RocketMQProperties rocketMQProperties) {
+
+        RocketMQProperties.Producer producerConfig = rocketMQProperties.getProducer();
+        String groupName = producerConfig.getGroup();
+        Assert.hasText(groupName, "[spring.rocketmq.producer.group] must not be null");
+
+        DefaultMQProducer producer = new DefaultMQProducer(producerConfig.getGroup());
+        producer.setNamesrvAddr(rocketMQProperties.getNameServer());
+        producer.setSendMsgTimeout(producerConfig.getSendMsgTimeout());
+        producer.setRetryTimesWhenSendFailed(producerConfig.getRetryTimesWhenSendFailed());
+        producer.setRetryTimesWhenSendAsyncFailed(producerConfig.getRetryTimesWhenSendAsyncFailed());
+        producer.setMaxMessageSize(producerConfig.getMaxMessageSize());
+        producer.setCompressMsgBodyOverHowmuch(producerConfig.getCompressMsgBodyOverHowmuch());
+        producer.setRetryAnotherBrokerWhenNotStoreOK(producerConfig.isRetryAnotherBrokerWhenNotStoreOk());
+
+        return producer;
+    }
+
+    @Bean
+    @ConditionalOnClass(ObjectMapper.class)
+    @ConditionalOnMissingBean(name = "rocketMQMessageObjectMapper")
+    public ObjectMapper rocketMQMessageObjectMapper() {
+        return new ObjectMapper();
+    }
+
+    @Bean(destroyMethod = "destroy")
+    @ConditionalOnBean(DefaultMQProducer.class)
+    @ConditionalOnMissingBean(name = "rocketMQTemplate")
+    public RocketMQTemplate rocketMQTemplate(DefaultMQProducer mqProducer,
+        @Autowired(required = false)
+        @Qualifier("rocketMQMessageObjectMapper")
+            ObjectMapper objectMapper) {
+        RocketMQTemplate rocketMQTemplate = new RocketMQTemplate();
+        rocketMQTemplate.setProducer(mqProducer);
+        if (Objects.nonNull(objectMapper)) {
+            rocketMQTemplate.setObjectMapper(objectMapper);
+        }
+
+        return rocketMQTemplate;
+    }
+
+    @Configuration
+    @ConditionalOnClass(DefaultMQPushConsumer.class)
+    @EnableConfigurationProperties(RocketMQProperties.class)
+    @ConditionalOnProperty(prefix = "spring.rocketmq", value = "nameServer")
+    @Order
+    public static class ListenerContainerConfiguration implements ApplicationContextAware, InitializingBean {
+        private ConfigurableApplicationContext applicationContext;
+
+        private AtomicLong counter = new AtomicLong(0);
+
+        @Resource
+        private StandardEnvironment environment;
+
+        @Resource
+        private RocketMQProperties rocketMQProperties;
+
+        private ObjectMapper objectMapper;
+
+        public ListenerContainerConfiguration() {
+        }
+
+        @Autowired(required = false)
+        public ListenerContainerConfiguration(
+            @Qualifier("rocketMQMessageObjectMapper") ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+        }
+
+        @Override
+        public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+            this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+        }
+
+        @Override
+        public void afterPropertiesSet() throws Exception {
+            Map<String, Object> beans = this.applicationContext.getBeansWithAnnotation(RocketMQMessageListener.class);
+
+            if (Objects.nonNull(beans)) {
+                beans.forEach(this::registerContainer);
+            }
+        }
+
+        private void registerContainer(String beanName, Object bean) {
+            Class<?> clazz = AopUtils.getTargetClass(bean);
+
+            if (!RocketMQListener.class.isAssignableFrom(bean.getClass())) {
+                throw new IllegalStateException(clazz + " is not instance of " + RocketMQListener.class.getName());
+            }
+
+            RocketMQListener rocketMQListener = (RocketMQListener) bean;
+            RocketMQMessageListener annotation = clazz.getAnnotation(RocketMQMessageListener.class);
+            BeanDefinitionBuilder beanBuilder = BeanDefinitionBuilder.rootBeanDefinition(DefaultRocketMQListenerContainer.class);
+            beanBuilder.addPropertyValue("nameServer", rocketMQProperties.getNameServer());
+            beanBuilder.addPropertyValue("topic", environment.resolvePlaceholders(annotation.topic()));
+
+            beanBuilder.addPropertyValue("consumerGroup", environment.resolvePlaceholders(annotation.consumerGroup()));
+            beanBuilder.addPropertyValue("consumeMode", annotation.consumeMode());
+            beanBuilder.addPropertyValue("consumeThreadMax", annotation.consumeThreadMax());
+            beanBuilder.addPropertyValue("messageModel", annotation.messageModel());
+            beanBuilder.addPropertyValue("selectorExpress", environment.resolvePlaceholders(annotation.selectorExpress()));
+            beanBuilder.addPropertyValue("selectorType", annotation.selectorType());
+            beanBuilder.addPropertyValue("rocketMQListener", rocketMQListener);
+            if (Objects.nonNull(objectMapper)) {
+                beanBuilder.addPropertyValue("objectMapper", objectMapper);
+            }
+            beanBuilder.setDestroyMethodName("destroy");
+
+            String containerBeanName = String.format("%s_%s", DefaultRocketMQListenerContainer.class.getName(), counter.incrementAndGet());
+            DefaultListableBeanFactory beanFactory = (DefaultListableBeanFactory) applicationContext.getBeanFactory();
+            beanFactory.registerBeanDefinition(containerBeanName, beanBuilder.getBeanDefinition());
+
+            DefaultRocketMQListenerContainer container = beanFactory.getBean(containerBeanName, DefaultRocketMQListenerContainer.class);
+
+            if (!container.isStarted()) {
+                try {
+                    container.start();
+                } catch (Exception e) {
+                    log.error("started container failed. {}", container, e);
+                    throw new RuntimeException(e);
+                }
+            }
+
+            log.info("register rocketMQ listener to container, listenerBeanName:{}, containerBeanName:{}", beanName, containerBeanName);
+        }
+    }
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
@@ -51,9 +51,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.util.Assert;
 
-/**
- * RocketMqAutoConfiguration Created by aqlu on 2017/9/27.
- */
 @Configuration
 @EnableConfigurationProperties(RocketMQProperties.class)
 @ConditionalOnClass(MQClientAPIImpl.class)

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQProperties.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQProperties.java
@@ -20,9 +20,6 @@ package org.apache.rocketmq.spring.starter;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * RocketMQProperties Created by aqlu on 2017/9/27.
- */
 @SuppressWarnings("WeakerAccess")
 @ConfigurationProperties(prefix = "spring.rocketmq")
 @Data

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQProperties.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/RocketMQProperties.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * RocketMQProperties Created by aqlu on 2017/9/27.
+ */
+@SuppressWarnings("WeakerAccess")
+@ConfigurationProperties(prefix = "spring.rocketmq")
+@Data
+public class RocketMQProperties {
+
+    /**
+     * name server for rocketMQ, formats: `host:port;host:port`
+     */
+    private String nameServer;
+
+    private Producer producer;
+
+    @Data
+    public static class Producer {
+
+        /**
+         * name of producer
+         */
+        private String group;
+
+        /**
+         * millis of send message timeout
+         */
+        private int sendMsgTimeout = 3000;
+
+        /**
+         * Compress message body threshold, namely, message body larger than 4k will be compressed on default.
+         */
+        private int compressMsgBodyOverHowmuch = 1024 * 4;
+
+        /**
+         * <p> Maximum number of retry to perform internally before claiming sending failure in synchronous mode. </p>
+         * This may potentially cause message duplication which is up to application developers to resolve.
+         */
+        private int retryTimesWhenSendFailed = 2;
+
+        /**
+         * <p> Maximum number of retry to perform internally before claiming sending failure in asynchronous mode. </p>
+         * This may potentially cause message duplication which is up to application developers to resolve.
+         */
+        private int retryTimesWhenSendAsyncFailed = 2;
+
+        /**
+         * Indicate whether to retry another broker on sending failure internally.
+         */
+        private boolean retryAnotherBrokerWhenNotStoreOk = false;
+
+        /**
+         * Maximum allowed message size in bytes.
+         */
+        private int maxMessageSize = 1024 * 1024 * 4; // 4M
+
+    }
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/annotation/RocketMQMessageListener.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/annotation/RocketMQMessageListener.java
@@ -17,6 +17,7 @@
 
 package org.apache.rocketmq.spring.starter.annotation;
 
+import org.apache.rocketmq.common.filter.ExpressionType;
 import org.apache.rocketmq.spring.starter.enums.ConsumeMode;
 import org.apache.rocketmq.spring.starter.enums.SelectorType;
 import java.lang.annotation.Documented;
@@ -31,18 +32,45 @@ import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 @Documented
 public @interface RocketMQMessageListener {
 
+    /**
+     * Consumers of the same role is required to have exactly same subscriptions and consumerGroup to correctly achieve
+     * load balance. It's required and needs to be globally unique.
+     * </p>
+     * <p>
+     * See <a href="http://rocketmq.apache.org/docs/core-concept/">here</a> for further discussion.
+     */
     String consumerGroup();
 
+    /**
+     * Topic name
+     */
     String topic();
 
+    /**
+     * Control how to selector message
+     *
+     * @see ExpressionType
+     */
     SelectorType selectorType() default SelectorType.TAG;
 
+    /**
+     * Control which message can be select. Grammar please see {@link ExpressionType#TAG} and {@link ExpressionType#SQL92}
+     */
     String selectorExpress() default "*";
 
+    /**
+     * Control consume mode, you can choice receive message concurrently or orderly
+     */
     ConsumeMode consumeMode() default ConsumeMode.CONCURRENTLY;
 
+    /**
+     * Control message mode, if you want all subscribers receive message all message, broadcasting is a good choice.
+     */
     MessageModel messageModel() default MessageModel.CLUSTERING;
 
+    /**
+     * Max consumer thread number
+     */
     int consumeThreadMax() default 64;
 
 }

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/annotation/RocketMQMessageListener.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/annotation/RocketMQMessageListener.java
@@ -26,9 +26,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 
-/**
- * RocketMQMessageListener Created by aqlu on 2017/9/27.
- */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/annotation/RocketMQMessageListener.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/annotation/RocketMQMessageListener.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter.annotation;
+
+import org.apache.rocketmq.spring.starter.enums.ConsumeMode;
+import org.apache.rocketmq.spring.starter.enums.SelectorType;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
+
+/**
+ * RocketMQMessageListener Created by aqlu on 2017/9/27.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RocketMQMessageListener {
+
+    String consumerGroup();
+
+    String topic();
+
+    SelectorType selectorType() default SelectorType.TAG;
+
+    String selectorExpress() default "*";
+
+    ConsumeMode consumeMode() default ConsumeMode.CONCURRENTLY;
+
+    MessageModel messageModel() default MessageModel.CLUSTERING;
+
+    int consumeThreadMax() default 64;
+
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/DefaultRocketMQListenerContainer.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/DefaultRocketMQListenerContainer.java
@@ -114,7 +114,7 @@ public class DefaultRocketMQListenerContainer implements InitializingBean, Rocke
     }
 
     @Override
-    public void destroy() throws Exception {
+    public void destroy() {
         this.setStarted(false);
         if (Objects.nonNull(consumer)) {
             consumer.shutdown();
@@ -273,7 +273,7 @@ public class DefaultRocketMQListenerContainer implements InitializingBean, Rocke
         }
 
         switch (consumeMode) {
-            case Orderly:
+            case ORDERLY:
                 consumer.setMessageListener(new DefaultMessageListenerOrderly());
                 break;
             case CONCURRENTLY:

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/DefaultRocketMQListenerContainer.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/DefaultRocketMQListenerContainer.java
@@ -42,9 +42,6 @@ import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 
-/**
- * AbstractRocketMQConsumer Created by aqlu on 2017/9/28.
- */
 @SuppressWarnings("WeakerAccess")
 @Slf4j
 public class DefaultRocketMQListenerContainer implements InitializingBean, RocketMQListenerContainer {

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/DefaultRocketMQListenerContainer.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/DefaultRocketMQListenerContainer.java
@@ -150,7 +150,7 @@ public class DefaultRocketMQListenerContainer implements InitializingBean, Rocke
                     long now = System.currentTimeMillis();
                     rocketMQListener.onMessage(doConvertMessage(messageExt));
                     long costTime = System.currentTimeMillis() - now;
-                    log.info("consume {} cost: {} ms", messageExt.getMsgId(), costTime);
+                    log.debug("consume {} cost: {} ms", messageExt.getMsgId(), costTime);
                 } catch (Exception e) {
                     log.warn("consume message failed. messageExt:{}", messageExt, e);
                     context.setDelayLevelWhenNextConsume(delayLevelWhenNextConsume);

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/DefaultRocketMQListenerContainer.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/DefaultRocketMQListenerContainer.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.spring.starter.enums.ConsumeMode;
+import org.apache.rocketmq.spring.starter.enums.SelectorType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.MessageSelector;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * AbstractRocketMQConsumer Created by aqlu on 2017/9/28.
+ */
+@SuppressWarnings("WeakerAccess")
+@Slf4j
+public class DefaultRocketMQListenerContainer implements InitializingBean, RocketMQListenerContainer {
+
+    @Setter
+    @Getter
+    private long suspendCurrentQueueTimeMillis = 1000;
+
+    /**
+     * Message consume retry strategy<br> -1,no retry,put into DLQ directly<br> 0,broker control retry frequency<br>
+     * >0,client control retry frequency
+     */
+    @Setter
+    @Getter
+    private int delayLevelWhenNextConsume = 0;
+
+    @Setter
+    @Getter
+    private String consumerGroup;
+
+    @Setter
+    @Getter
+    private String nameServer;
+
+    @Setter
+    @Getter
+    private String topic;
+
+    @Setter
+    @Getter
+    private ConsumeMode consumeMode = ConsumeMode.CONCURRENTLY;
+
+    @Setter
+    @Getter
+    private SelectorType selectorType = SelectorType.TAG;
+
+    @Setter
+    @Getter
+    private String selectorExpress = "*";
+
+    @Setter
+    @Getter
+    private MessageModel messageModel = MessageModel.CLUSTERING;
+
+    @Setter
+    @Getter
+    private int consumeThreadMax = 64;
+
+    @Getter
+    @Setter
+    private String charset = "UTF-8";
+
+    @Setter
+    @Getter
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Setter
+    @Getter
+    private boolean started;
+
+    @Setter
+    private RocketMQListener rocketMQListener;
+
+    private DefaultMQPushConsumer consumer;
+
+    private Class messageType;
+
+    public void setupMessageListener(RocketMQListener rocketMQListener) {
+        this.rocketMQListener = rocketMQListener;
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        this.setStarted(false);
+        if (Objects.nonNull(consumer)) {
+            consumer.shutdown();
+        }
+        log.info("container destroyed, {}", this.toString());
+    }
+
+    public synchronized void start() throws MQClientException {
+
+        if (this.isStarted()) {
+            throw new IllegalStateException("container already started. " + this.toString());
+        }
+
+        initRocketMQPushConsumer();
+
+        // parse message type
+        this.messageType = getMessageType();
+        log.debug("msgType: {}", messageType.getName());
+
+        consumer.start();
+        this.setStarted(true);
+
+        log.info("started container: {}", this.toString());
+    }
+
+    public class DefaultMessageListenerConcurrently implements MessageListenerConcurrently {
+
+        @SuppressWarnings("unchecked")
+        public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs, ConsumeConcurrentlyContext context) {
+            for (MessageExt messageExt : msgs) {
+                log.debug("received msg: {}", messageExt);
+                try {
+                    long now = System.currentTimeMillis();
+                    rocketMQListener.onMessage(doConvertMessage(messageExt));
+                    long costTime = System.currentTimeMillis() - now;
+                    log.info("consume {} cost: {} ms", messageExt.getMsgId(), costTime);
+                } catch (Exception e) {
+                    log.warn("consume message failed. messageExt:{}", messageExt, e);
+                    context.setDelayLevelWhenNextConsume(delayLevelWhenNextConsume);
+                    return ConsumeConcurrentlyStatus.RECONSUME_LATER;
+                }
+            }
+
+            return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+        }
+    }
+
+    public class DefaultMessageListenerOrderly implements MessageListenerOrderly {
+
+        @SuppressWarnings("unchecked")
+        public ConsumeOrderlyStatus consumeMessage(List<MessageExt> msgs, ConsumeOrderlyContext context) {
+            for (MessageExt messageExt : msgs) {
+                log.debug("received msg: {}", messageExt);
+                try {
+                    long now = System.currentTimeMillis();
+                    rocketMQListener.onMessage(doConvertMessage(messageExt));
+                    long costTime = System.currentTimeMillis() - now;
+                    log.info("consume {} cost: {} ms", messageExt.getMsgId(), costTime);
+                } catch (Exception e) {
+                    log.warn("consume message failed. messageExt:{}", messageExt, e);
+                    context.setSuspendCurrentQueueTimeMillis(suspendCurrentQueueTimeMillis);
+                    return ConsumeOrderlyStatus.SUSPEND_CURRENT_QUEUE_A_MOMENT;
+                }
+            }
+
+            return ConsumeOrderlyStatus.SUCCESS;
+        }
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        start();
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultRocketMQListenerContainer{" +
+            "consumerGroup='" + consumerGroup + '\'' +
+            ", nameServer='" + nameServer + '\'' +
+            ", topic='" + topic + '\'' +
+            ", consumeMode=" + consumeMode +
+            ", selectorType=" + selectorType +
+            ", selectorExpress='" + selectorExpress + '\'' +
+            ", messageModel=" + messageModel +
+            '}';
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object doConvertMessage(MessageExt messageExt) {
+        if (Objects.equals(messageType, MessageExt.class)) {
+            return messageExt;
+        } else {
+            String str = new String(messageExt.getBody(), Charset.forName(charset));
+            if (Objects.equals(messageType, String.class)) {
+                return str;
+            } else {
+                // if msgType not string, use objectMapper change it.
+                try {
+                    return objectMapper.readValue(str, messageType);
+                } catch (Exception e) {
+                    log.info("convert failed. str:{}, msgType:{}", str, messageType);
+                    throw new RuntimeException("cannot convert message to " + messageType, e);
+                }
+            }
+        }
+    }
+
+    private Class getMessageType() {
+        Type[] interfaces = rocketMQListener.getClass().getGenericInterfaces();
+        if (Objects.nonNull(interfaces)) {
+            for (Type type : interfaces) {
+                if (type instanceof ParameterizedType) {
+                    ParameterizedType parameterizedType = (ParameterizedType) type;
+                    if (Objects.equals(parameterizedType.getRawType(), RocketMQListener.class)) {
+                        Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+                        if (Objects.nonNull(actualTypeArguments) && actualTypeArguments.length > 0) {
+                            return (Class) actualTypeArguments[0];
+                        } else {
+                            return Object.class;
+                        }
+                    }
+                }
+            }
+
+            return Object.class;
+        } else {
+            return Object.class;
+        }
+    }
+
+    private void initRocketMQPushConsumer() throws MQClientException {
+
+        Assert.notNull(rocketMQListener, "Property 'rocketMQListener' is required");
+        Assert.notNull(consumerGroup, "Property 'consumerGroup' is required");
+        Assert.notNull(nameServer, "Property 'nameServer' is required");
+        Assert.notNull(topic, "Property 'topic' is required");
+
+        consumer = new DefaultMQPushConsumer(consumerGroup);
+        consumer.setNamesrvAddr(nameServer);
+        consumer.setConsumeThreadMax(consumeThreadMax);
+        if (consumeThreadMax < consumer.getConsumeThreadMin()) {
+            consumer.setConsumeThreadMin(consumeThreadMax);
+        }
+
+        consumer.setMessageModel(messageModel);
+
+        switch (selectorType) {
+            case TAG:
+                consumer.subscribe(topic, selectorExpress);
+                break;
+            case SQL92:
+                consumer.subscribe(topic, MessageSelector.bySql(selectorExpress));
+                break;
+            default:
+                throw new IllegalArgumentException("Property 'selectorType' was wrong.");
+        }
+
+        switch (consumeMode) {
+            case Orderly:
+                consumer.setMessageListener(new DefaultMessageListenerOrderly());
+                break;
+            case CONCURRENTLY:
+                consumer.setMessageListener(new DefaultMessageListenerConcurrently());
+                break;
+            default:
+                throw new IllegalArgumentException("Property 'consumeMode' was wrong.");
+        }
+
+        // provide an entryway to custom setting RocketMQ consumer
+        if (rocketMQListener instanceof RocketMQPushConsumerLifecycleListener) {
+            ((RocketMQPushConsumerLifecycleListener) rocketMQListener).prepareStart(consumer);
+        }
+
+    }
+
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/DefaultRocketMQListenerContainerConstants.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/DefaultRocketMQListenerContainerConstants.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter.core;
+
+/**
+ * Constants Created by aqlu on 2017/11/16.
+ */
+public final class DefaultRocketMQListenerContainerConstants {
+    public static final String PROP_NAMESERVER = "nameServer";
+    public static final String PROP_TOPIC = "topic";
+    public static final String PROP_CONSUMER_GROUP = "consumerGroup";
+    public static final String PROP_CONSUME_MODE = "consumeMode";
+    public static final String PROP_CONSUME_THREAD_MAX = "consumeThreadMax";
+    public static final String PROP_MESSAGE_MODEL = "messageModel";
+    public static final String PROP_SELECTOR_EXPRESS = "selectorExpress";
+    public static final String PROP_SELECTOR_TYPE = "selectorType";
+    public static final String PROP_ROCKETMQ_LISTENER = "rocketMQListener";
+    public static final String PROP_OBJECT_MAPPER = "objectMapper";
+    public static final String METHOD_DESTROY = "destroy";
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQConsumerLifecycleListener.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQConsumerLifecycleListener.java
@@ -17,9 +17,6 @@
 
 package org.apache.rocketmq.spring.starter.core;
 
-/**
- * RocketMQ Consumer Lifecycle Listener Created by aqlu on 2017/9/30.
- */
 public interface RocketMQConsumerLifecycleListener<T> {
     void prepareStart(final T consumer);
 }

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQConsumerLifecycleListener.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQConsumerLifecycleListener.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter.core;
+
+/**
+ * RocketMQ Consumer Lifecycle Listener Created by aqlu on 2017/9/30.
+ */
+public interface RocketMQConsumerLifecycleListener<T> {
+    void prepareStart(final T consumer);
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQListener.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQListener.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter.core;
+
+/**
+ * RocketMQListener Created by aqlu on 2017/9/28.
+ */
+public interface RocketMQListener<T> {
+    void onMessage(T message);
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQListener.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQListener.java
@@ -17,9 +17,6 @@
 
 package org.apache.rocketmq.spring.starter.core;
 
-/**
- * RocketMQListener Created by aqlu on 2017/9/28.
- */
 public interface RocketMQListener<T> {
     void onMessage(T message);
 }

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQListenerContainer.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQListenerContainer.java
@@ -19,9 +19,6 @@ package org.apache.rocketmq.spring.starter.core;
 
 import org.springframework.beans.factory.DisposableBean;
 
-/**
- * RocketMQListenerContainer Created by aqlu on 2017/9/28.
- */
 public interface RocketMQListenerContainer extends DisposableBean {
 
     /**

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQListenerContainer.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQListenerContainer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter.core;
+
+import org.springframework.beans.factory.DisposableBean;
+
+/**
+ * RocketMQListenerContainer Created by aqlu on 2017/9/28.
+ */
+public interface RocketMQListenerContainer extends DisposableBean {
+
+    /**
+     * Setup the message listener to use. Throws an {@link IllegalArgumentException} if that message listener type is
+     * not supported.
+     */
+    void setupMessageListener(RocketMQListener<?> messageListener);
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQPushConsumerLifecycleListener.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQPushConsumerLifecycleListener.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter.core;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+
+/**
+ * RocketMQ PushConsumer Lifecycle Listener Created by aqlu on 2017/9/30.
+ */
+public interface RocketMQPushConsumerLifecycleListener extends RocketMQConsumerLifecycleListener<DefaultMQPushConsumer> {
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQPushConsumerLifecycleListener.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQPushConsumerLifecycleListener.java
@@ -19,8 +19,5 @@ package org.apache.rocketmq.spring.starter.core;
 
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
 
-/**
- * RocketMQ PushConsumer Lifecycle Listener Created by aqlu on 2017/9/30.
- */
 public interface RocketMQPushConsumerLifecycleListener extends RocketMQConsumerLifecycleListener<DefaultMQPushConsumer> {
 }

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
@@ -1,0 +1,513 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.MessageQueueSelector;
+import org.apache.rocketmq.client.producer.SendCallback;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.selector.SelectMessageQueueByHash;
+import org.apache.rocketmq.common.message.MessageConst;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.core.AbstractMessageSendingTemplate;
+import org.springframework.messaging.core.MessagePostProcessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.Assert;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Helper class for RocketMQ sending Messages Created by aqlu on 2017/9/28.
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+@Slf4j
+public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> implements InitializingBean, DisposableBean {
+
+    @Getter
+    @Setter
+    private DefaultMQProducer producer;
+
+    @Setter
+    @Getter
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Getter
+    @Setter
+    private String charset = "UTF-8";
+
+    @Getter
+    @Setter
+    private MessageQueueSelector messageQueueSelector = new SelectMessageQueueByHash();
+
+    /**
+     * <p> Send message in synchronous mode. This method returns only when the sending procedure totally completes.
+     * Reliable synchronous transmission is used in extensive scenes, such as important notification messages, SMS
+     * notification, SMS marketing system, etc.. </p>
+     *
+     * <strong>Warn:</strong> this method has internal retry-mechanism, that is, internal implementation will retry
+     * {@link DefaultMQProducer#getRetryTimesWhenSendFailed} times before claiming failure. As a result, multiple
+     * messages may potentially delivered to broker(s). It's up to the application developers to resolve potential
+     * duplication issue.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param message {@link org.springframework.messaging.Message}
+     * @return {@link SendResult}
+     */
+    public SendResult syncSend(String destination, Message<?> message) {
+        return syncSend(destination, message, producer.getSendMsgTimeout());
+    }
+
+    /**
+     * Same to {@link #syncSend(String, Message)} with send timeout specified in addition.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param message {@link org.springframework.messaging.Message}
+     * @param timeout send timeout with millis
+     * @return {@link SendResult}
+     */
+    public SendResult syncSend(String destination, Message<?> message, long timeout) {
+        if (Objects.isNull(message) || Objects.isNull(message.getPayload())) {
+            log.info("syncSend failed. destination:{}, message is null ", destination);
+            throw new IllegalArgumentException("`message` and `message.payload` cannot be null");
+        }
+
+        try {
+            long now = System.currentTimeMillis();
+            org.apache.rocketmq.common.message.Message rocketMsg = convertToRocketMsg(destination, message);
+            SendResult sendResult = producer.send(rocketMsg, timeout);
+            long costTime = System.currentTimeMillis() - now;
+            log.info("send message cost: {} ms, msgId:{}", costTime, sendResult.getMsgId());
+            return sendResult;
+        } catch (Exception e) {
+            log.info("syncSend failed. destination:{}, message:{} ", destination, message);
+            throw new MessagingException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Same to {@link #syncSend(String, Message)}.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param payload the Object to use as payload
+     * @return {@link SendResult}
+     */
+    public SendResult syncSend(String destination, Object payload) {
+        return syncSend(destination, payload, producer.getSendMsgTimeout());
+    }
+
+    /**
+     * Same to {@link #syncSend(String, Object)} with send timeout specified in addition.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param payload the Object to use as payload
+     * @param timeout send timeout with millis
+     * @return {@link SendResult}
+     */
+    public SendResult syncSend(String destination, Object payload, long timeout) {
+        Message<?> message = this.doConvert(payload, null, null);
+        return syncSend(destination, message, timeout);
+    }
+
+    /**
+     * Same to {@link #syncSend(String, Message)} with send orderly with hashKey by specified.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param message {@link org.springframework.messaging.Message}
+     * @param hashKey use this key to select queue. for example: orderId, productId ...
+     * @return {@link SendResult}
+     */
+    public SendResult syncSendOrderly(String destination, Message<?> message, String hashKey) {
+        return syncSendOrderly(destination, message, hashKey, producer.getSendMsgTimeout());
+    }
+
+    /**
+     * Same to {@link #syncSendOrderly(String, Message, String)} with send timeout specified in addition.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param message {@link org.springframework.messaging.Message}
+     * @param hashKey use this key to select queue. for example: orderId, productId ...
+     * @param timeout send timeout with millis
+     * @return {@link SendResult}
+     */
+    public SendResult syncSendOrderly(String destination, Message<?> message, String hashKey, long timeout) {
+        if (Objects.isNull(message) || Objects.isNull(message.getPayload())) {
+            log.info("syncSendOrderly failed. destination:{}, message is null ", destination);
+            throw new IllegalArgumentException("`message` and `message.payload` cannot be null");
+        }
+
+        try {
+            long now = System.currentTimeMillis();
+            org.apache.rocketmq.common.message.Message rocketMsg = convertToRocketMsg(destination, message);
+            SendResult sendResult = producer.send(rocketMsg, messageQueueSelector, hashKey, timeout);
+            long costTime = System.currentTimeMillis() - now;
+            log.info("send message cost: {} ms, msgId:{}", costTime, sendResult.getMsgId());
+            return sendResult;
+        } catch (Exception e) {
+            log.info("syncSendOrderly failed. destination:{}, message:{} ", destination, message);
+            throw new MessagingException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Same to {@link #syncSend(String, Object)} with send orderly with hashKey by specified.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param payload the Object to use as payload
+     * @param hashKey use this key to select queue. for example: orderId, productId ...
+     * @return {@link SendResult}
+     */
+    public SendResult syncSendOrderly(String destination, Object payload, String hashKey) {
+        return syncSendOrderly(destination, payload, hashKey, producer.getSendMsgTimeout());
+    }
+
+    /**
+     * Same to {@link #syncSendOrderly(String, Object, String)} with send timeout specified in addition.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param payload the Object to use as payload
+     * @param hashKey use this key to select queue. for example: orderId, productId ...
+     * @param timeout send timeout with millis
+     * @return {@link SendResult}
+     */
+    public SendResult syncSendOrderly(String destination, Object payload, String hashKey, long timeout) {
+        Message<?> message = this.doConvert(payload, null, null);
+        return syncSendOrderly(destination, message, hashKey, producer.getSendMsgTimeout());
+    }
+
+    /**
+     * Same to {@link #asyncSend(String, Message, SendCallback)} with send timeout specified in addition.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param message {@link org.springframework.messaging.Message}
+     * @param sendCallback {@link SendCallback}
+     * @param timeout send timeout with millis
+     */
+    public void asyncSend(String destination, Message<?> message, SendCallback sendCallback, long timeout) {
+        if (Objects.isNull(message) || Objects.isNull(message.getPayload())) {
+            log.info("asyncSend failed. destination:{}, message is null ", destination);
+            throw new IllegalArgumentException("`message` and `message.payload` cannot be null");
+        }
+
+        try {
+            org.apache.rocketmq.common.message.Message rocketMsg = convertToRocketMsg(destination, message);
+            producer.send(rocketMsg, sendCallback, timeout);
+        } catch (Exception e) {
+            log.info("asyncSend failed. destination:{}, message:{} ", destination, message);
+            throw new MessagingException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * <p> Send message to broker asynchronously. asynchronous transmission is generally used in response time sensitive
+     * business scenarios. </p>
+     *
+     * This method returns immediately. On sending completion, <code>sendCallback</code> will be executed.
+     *
+     * Similar to {@link #syncSend(String, Object)}, internal implementation would potentially retry up to {@link
+     * DefaultMQProducer#getRetryTimesWhenSendAsyncFailed} times before claiming sending failure, which may yield
+     * message duplication and application developers are the one to resolve this potential issue.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param message {@link org.springframework.messaging.Message}
+     * @param sendCallback {@link SendCallback}
+     */
+    public void asyncSend(String destination, Message<?> message, SendCallback sendCallback) {
+        asyncSend(destination, message, sendCallback, producer.getSendMsgTimeout());
+    }
+
+    /**
+     * Same to {@link #asyncSend(String, Object, SendCallback)} with send timeout specified in addition.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param payload the Object to use as payload
+     * @param sendCallback {@link SendCallback}
+     * @param timeout send timeout with millis
+     */
+    public void asyncSend(String destination, Object payload, SendCallback sendCallback, long timeout) {
+        Message<?> message = this.doConvert(payload, null, null);
+        asyncSend(destination, message, sendCallback, timeout);
+    }
+
+    /**
+     * Same to {@link #asyncSend(String, Message, SendCallback)}.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param payload the Object to use as payload
+     * @param sendCallback {@link SendCallback}
+     */
+    public void asyncSend(String destination, Object payload, SendCallback sendCallback) {
+        asyncSend(destination, payload, sendCallback, producer.getSendMsgTimeout());
+    }
+
+    /**
+     * Same to {@link #asyncSendOrderly(String, Message, String, SendCallback)} with send timeout specified in
+     * addition.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param message {@link org.springframework.messaging.Message}
+     * @param hashKey use this key to select queue. for example: orderId, productId ...
+     * @param sendCallback {@link SendCallback}
+     * @param timeout send timeout with millis
+     */
+    public void asyncSendOrderly(String destination, Message<?> message, String hashKey, SendCallback sendCallback,
+        long timeout) {
+        if (Objects.isNull(message) || Objects.isNull(message.getPayload())) {
+            log.info("asyncSendOrderly failed. destination:{}, message is null ", destination);
+            throw new IllegalArgumentException("`message` and `message.payload` cannot be null");
+        }
+
+        try {
+            org.apache.rocketmq.common.message.Message rocketMsg = convertToRocketMsg(destination, message);
+            producer.send(rocketMsg, messageQueueSelector, hashKey, sendCallback, timeout);
+        } catch (Exception e) {
+            log.info("asyncSendOrderly failed. destination:{}, message:{} ", destination, message);
+            throw new MessagingException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Same to {@link #asyncSend(String, Message, SendCallback)} with send orderly with hashKey by specified.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param message {@link org.springframework.messaging.Message}
+     * @param hashKey use this key to select queue. for example: orderId, productId ...
+     * @param sendCallback {@link SendCallback}
+     */
+    public void asyncSendOrderly(String destination, Message<?> message, String hashKey, SendCallback sendCallback) {
+        asyncSendOrderly(destination, message, hashKey, sendCallback, producer.getSendMsgTimeout());
+    }
+
+    /**
+     * Same to {@link #asyncSendOrderly(String, Message, String, SendCallback)}.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param payload the Object to use as payload
+     * @param hashKey use this key to select queue. for example: orderId, productId ...
+     * @param sendCallback {@link SendCallback}
+     */
+    public void asyncSendOrderly(String destination, Object payload, String hashKey, SendCallback sendCallback) {
+        asyncSendOrderly(destination, payload, hashKey, sendCallback, producer.getSendMsgTimeout());
+    }
+
+    /**
+     * Same to {@link #asyncSendOrderly(String, Object, String, SendCallback)} with send timeout specified in addition.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param payload the Object to use as payload
+     * @param hashKey use this key to select queue. for example: orderId, productId ...
+     * @param sendCallback {@link SendCallback}
+     * @param timeout send timeout with millis
+     */
+    public void asyncSendOrderly(String destination, Object payload, String hashKey, SendCallback sendCallback,
+        long timeout) {
+        Message<?> message = this.doConvert(payload, null, null);
+        asyncSendOrderly(destination, message, hashKey, sendCallback, timeout);
+    }
+
+    /**
+     * Similar to <a href="https://en.wikipedia.org/wiki/User_Datagram_Protocol">UDP</a>, this method won't wait for
+     * acknowledgement from broker before return. Obviously, it has maximums throughput yet potentials of message loss.
+     *
+     * One-way transmission is used for cases requiring moderate reliability, such as log collection.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param message {@link org.springframework.messaging.Message}
+     */
+    public void sendOneWay(String destination, Message<?> message) {
+        if (Objects.isNull(message) || Objects.isNull(message.getPayload())) {
+            log.info("sendOneWay failed. destination:{}, message is null ", destination);
+            throw new IllegalArgumentException("`message` and `message.payload` cannot be null");
+        }
+
+        try {
+            org.apache.rocketmq.common.message.Message rocketMsg = convertToRocketMsg(destination, message);
+            producer.sendOneway(rocketMsg);
+        } catch (Exception e) {
+            log.info("sendOneWay failed. destination:{}, message:{} ", destination, message);
+            throw new MessagingException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Same to {@link #sendOneWay(String, Message)}
+     *
+     * @param destination formats: `topicName:tags`
+     * @param payload the Object to use as payload
+     */
+    public void sendOneWay(String destination, Object payload) {
+        Message<?> message = this.doConvert(payload, null, null);
+        sendOneWay(destination, message);
+    }
+
+    /**
+     * Same to {@link #sendOneWay(String, Message)} with send orderly with hashKey by specified.
+     *
+     * @param destination formats: `topicName:tags`
+     * @param message {@link org.springframework.messaging.Message}
+     * @param hashKey use this key to select queue. for example: orderId, productId ...
+     */
+    public void sendOneWayOrderly(String destination, Message<?> message, String hashKey) {
+        if (Objects.isNull(message) || Objects.isNull(message.getPayload())) {
+            log.info("sendOneWayOrderly failed. destination:{}, message is null ", destination);
+            throw new IllegalArgumentException("`message` and `message.payload` cannot be null");
+        }
+
+        try {
+            org.apache.rocketmq.common.message.Message rocketMsg = convertToRocketMsg(destination, message);
+            producer.sendOneway(rocketMsg, messageQueueSelector, hashKey);
+        } catch (Exception e) {
+            log.info("sendOneWayOrderly failed. destination:{}, message:{}", destination, message);
+            throw new MessagingException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Same to {@link #sendOneWayOrderly(String, Message, String)}
+     *
+     * @param destination formats: `topicName:tags`
+     * @param payload the Object to use as payload
+     */
+    public void sendOneWayOrderly(String destination, Object payload, String hashKey) {
+        Message<?> message = this.doConvert(payload, null, null);
+        sendOneWayOrderly(destination, message, hashKey);
+    }
+
+    public void afterPropertiesSet() throws Exception {
+        Assert.notNull(producer, "Property 'producer' is required");
+        producer.start();
+    }
+
+    protected void doSend(String destination, Message<?> message) {
+        SendResult sendResult = syncSend(destination, message);
+        log.debug("send message to `{}` finished. result:{}", destination, sendResult);
+    }
+
+    /**
+     * Convert spring message to rocketMQ message
+     *
+     * @param destination formats: `topicName:tags`
+     * @param message {@link org.springframework.messaging.Message}
+     * @return instance of {@link org.apache.rocketmq.common.message.Message}
+     */
+    private org.apache.rocketmq.common.message.Message convertToRocketMsg(String destination, Message<?> message) {
+        Object payloadObj = message.getPayload();
+        byte[] payloads;
+
+        if (payloadObj instanceof String) {
+            payloads = ((String) payloadObj).getBytes(Charset.forName(charset));
+        } else {
+            try {
+                String jsonObj = this.objectMapper.writeValueAsString(payloadObj);
+                payloads = jsonObj.getBytes(Charset.forName(charset));
+            } catch (Exception e) {
+                throw new RuntimeException("convert to RocketMQ message failed.", e);
+            }
+        }
+
+        String[] tempArr = destination.split(":", 2);
+        String topic = tempArr[0];
+        String tags = "";
+        if (tempArr.length > 1) {
+            tags = tempArr[1];
+        }
+
+        org.apache.rocketmq.common.message.Message rocketMsg = new org.apache.rocketmq.common.message.Message(topic, tags, payloads);
+
+        MessageHeaders headers = message.getHeaders();
+        if (Objects.nonNull(headers) && !headers.isEmpty()) {
+            Object keys = headers.get(MessageConst.PROPERTY_KEYS);
+            if (!StringUtils.isEmpty(keys)) { // if headers has 'KEYS', set rocketMQ message key
+                rocketMsg.setKeys(keys.toString());
+            }
+
+            // set rocketMQ message flag
+            Object flagObj = headers.getOrDefault("FLAG", "0");
+            int flag = 0;
+            try {
+                flag = Integer.parseInt(flagObj.toString());
+            } catch (NumberFormatException e) {
+                // ignore
+                log.info("flag must be integer, flagObj:{}", flagObj);
+            }
+            rocketMsg.setFlag(flag);
+
+            // set rocketMQ message waitStoreMsgOkObj
+            Object waitStoreMsgOkObj = headers.getOrDefault("WAIT_STORE_MSG_OK", "true");
+            boolean waitStoreMsgOK = Boolean.TRUE.equals(waitStoreMsgOkObj);
+            rocketMsg.setWaitStoreMsgOK(waitStoreMsgOK);
+
+            headers.entrySet().stream()
+                .filter(entry -> !Objects.equals(entry.getKey(), MessageConst.PROPERTY_KEYS)
+                    && !Objects.equals(entry.getKey(), "FLAG")
+                    && !Objects.equals(entry.getKey(), "WAIT_STORE_MSG_OK")) // exclude "KEYS", "FLAG", "WAIT_STORE_MSG_OK"
+                .forEach(entry -> {
+                    rocketMsg.putUserProperty("USERS_" + entry.getKey(), String.valueOf(entry.getValue())); // add other properties with prefix "USERS_"
+                });
+
+        }
+
+        return rocketMsg;
+    }
+
+    @Override
+    protected Message<?> doConvert(Object payload, Map<String, Object> headers, MessagePostProcessor postProcessor) {
+        String content;
+        if (payload instanceof String) {
+            content = (String) payload;
+        } else {
+            // if payload not as string, use objectMapper change it.
+            try {
+                content = objectMapper.writeValueAsString(payload);
+            } catch (JsonProcessingException e) {
+                log.info("convert to payload to String failed. payload:{}", payload);
+                throw new RuntimeException("convert to payload to String failed.", e);
+            }
+        }
+
+        MessageBuilder<?> builder = MessageBuilder.withPayload(content);
+        if (headers != null) {
+            builder.copyHeaders(headers);
+        }
+        builder.setHeaderIfAbsent(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.TEXT_PLAIN);
+
+        Message<?> message = builder.build();
+        if (postProcessor != null) {
+            message = postProcessor.postProcessMessage(message);
+        }
+        return message;
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        if (Objects.nonNull(producer)) {
+            producer.shutdown();
+        }
+    }
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
@@ -100,7 +100,7 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
             org.apache.rocketmq.common.message.Message rocketMsg = convertToRocketMsg(destination, message);
             SendResult sendResult = producer.send(rocketMsg, timeout);
             long costTime = System.currentTimeMillis() - now;
-            log.info("send message cost: {} ms, msgId:{}", costTime, sendResult.getMsgId());
+            log.debug("send message cost: {} ms, msgId:{}", costTime, sendResult.getMsgId());
             return sendResult;
         } catch (Exception e) {
             log.info("syncSend failed. destination:{}, message:{} ", destination, message);
@@ -164,7 +164,7 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
             org.apache.rocketmq.common.message.Message rocketMsg = convertToRocketMsg(destination, message);
             SendResult sendResult = producer.send(rocketMsg, messageQueueSelector, hashKey, timeout);
             long costTime = System.currentTimeMillis() - now;
-            log.info("send message cost: {} ms, msgId:{}", costTime, sendResult.getMsgId());
+            log.debug("send message cost: {} ms, msgId:{}", costTime, sendResult.getMsgId());
             return sendResult;
         } catch (Exception e) {
             log.info("syncSendOrderly failed. destination:{}, message:{} ", destination, message);

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
@@ -483,7 +483,7 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
             try {
                 content = objectMapper.writeValueAsString(payload);
             } catch (JsonProcessingException e) {
-                log.info("convert to payload to String failed. payload:{}", payload);
+                log.info("convert payload to String failed. payload:{}", payload);
                 throw new RuntimeException("convert to payload to String failed.", e);
             }
         }
@@ -502,7 +502,7 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
     }
 
     @Override
-    public void destroy() throws Exception {
+    public void destroy() {
         if (Objects.nonNull(producer)) {
             producer.shutdown();
         }

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
@@ -43,9 +43,6 @@ import org.springframework.util.Assert;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.util.StringUtils;
 
-/**
- * Helper class for RocketMQ sending Messages Created by aqlu on 2017/9/28.
- */
 @SuppressWarnings({"WeakerAccess", "unused"})
 @Slf4j
 public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> implements InitializingBean, DisposableBean {

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/enums/ConsumeMode.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/enums/ConsumeMode.java
@@ -17,9 +17,6 @@
 
 package org.apache.rocketmq.spring.starter.enums;
 
-/**
- * Consume Mode Created by aqlu on 2017/9/28.
- */
 public enum ConsumeMode {
     /**
      * receive asynchronously delivered messages concurrently

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/enums/ConsumeMode.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/enums/ConsumeMode.java
@@ -26,5 +26,5 @@ public enum ConsumeMode {
     /**
      * receive asynchronously delivered messages orderly. one queue, one thread
      */
-    Orderly
+    ORDERLY
 }

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/enums/ConsumeMode.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/enums/ConsumeMode.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter.enums;
+
+/**
+ * Consume Mode Created by aqlu on 2017/9/28.
+ */
+public enum ConsumeMode {
+    /**
+     * receive asynchronously delivered messages concurrently
+     */
+    CONCURRENTLY,
+
+    /**
+     * receive asynchronously delivered messages orderly. one queue, one thread
+     */
+    Orderly
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/enums/SelectorType.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/enums/SelectorType.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter.enums;
+
+import org.apache.rocketmq.common.filter.ExpressionType;
+
+/**
+ * Selector Type Created by aqlu on 2017/9/28.
+ */
+public enum SelectorType {
+
+    /**
+     * @see ExpressionType#TAG
+     */
+    TAG,
+
+    /**
+     * @see ExpressionType#SQL92
+     */
+    SQL92
+}

--- a/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/enums/SelectorType.java
+++ b/spring-boot-starter-rocketmq/src/main/java/org/apache/rocketmq/spring/starter/enums/SelectorType.java
@@ -19,9 +19,6 @@ package org.apache.rocketmq.spring.starter.enums;
 
 import org.apache.rocketmq.common.filter.ExpressionType;
 
-/**
- * Selector Type Created by aqlu on 2017/9/28.
- */
 public enum SelectorType {
 
     /**

--- a/spring-boot-starter-rocketmq/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-starter-rocketmq/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.apache.rocketmq.spring.starter.RocketMQAutoConfiguration

--- a/spring-boot-starter-rocketmq/src/test/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfigurationTests.java
+++ b/spring-boot-starter-rocketmq/src/test/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfigurationTests.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.spring.starter.annotation.RocketMQMessageListener;
+import org.apache.rocketmq.spring.starter.core.DefaultRocketMQListenerContainer;
+import org.apache.rocketmq.spring.starter.core.RocketMQListener;
+import org.apache.rocketmq.spring.starter.core.RocketMQTemplate;
+import org.apache.rocketmq.spring.starter.enums.ConsumeMode;
+import org.apache.rocketmq.spring.starter.enums.SelectorType;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RocketMQAutoConfigurationTests Created by aqlu on 2017/10/10.
+ */
+public class RocketMQAutoConfigurationTests {
+
+    private static final String TEST_CONSUMER_GROUP = "my_consumer";
+
+    private static final String TEST_TOPIC = "test-topic";
+
+    private AnnotationConfigApplicationContext context;
+
+    @Test
+    public void rocketMQTemplate() {
+
+        load("spring.rocketmq.nameServer=127.0.0.1:9876",
+            "spring.rocketmq.producer.group=my_group",
+            "spring.rocketmq.producer.send-msg-timeout=30000",
+            "spring.rocketmq.producer.retry-times-when-send-async-failed=1",
+            "spring.rocketmq.producer.compress-msg-body-over-howmuch=1024",
+            "spring.rocketmq.producer.max-message-size=10240",
+            "spring.rocketmq.producer.retry-another-broker-when-not-store-ok=true",
+            "spring.rocketmq.producer.retry-times-when-send-failed=1");
+
+        assertThat(this.context.containsBean("rocketMQMessageObjectMapper")).isTrue();
+        assertThat(this.context.containsBean("mqProducer")).isTrue();
+        assertThat(this.context.containsBean("rocketMQTemplate")).isTrue();
+        assertThat(this.context.getBeansOfType(DefaultRocketMQListenerContainer.class)).isEmpty();
+
+        RocketMQTemplate rocketMQTemplate = this.context.getBean(RocketMQTemplate.class);
+        ObjectMapper objectMapper = this.context.getBean("rocketMQMessageObjectMapper", ObjectMapper.class);
+        assertThat(rocketMQTemplate.getObjectMapper()).isEqualTo(objectMapper);
+
+        DefaultMQProducer defaultMQProducer = rocketMQTemplate.getProducer();
+
+        assertThat(defaultMQProducer.getNamesrvAddr()).isEqualTo("127.0.0.1:9876");
+        assertThat(defaultMQProducer.getProducerGroup()).isEqualTo("my_group");
+        assertThat(defaultMQProducer.getSendMsgTimeout()).isEqualTo(30000);
+        assertThat(defaultMQProducer.getRetryTimesWhenSendAsyncFailed()).isEqualTo(1);
+        assertThat(defaultMQProducer.getCompressMsgBodyOverHowmuch()).isEqualTo(1024);
+        assertThat(defaultMQProducer.getMaxMessageSize()).isEqualTo(10240);
+        assertThat(defaultMQProducer.isRetryAnotherBrokerWhenNotStoreOK()).isTrue();
+        assertThat(defaultMQProducer.getRetryTimesWhenSendFailed()).isEqualTo(1);
+    }
+
+    @Test
+    public void enableProducer() {
+        load();
+        assertThat(this.context.containsBean("mqProducer")).isFalse();
+        assertThat(this.context.containsBean("rocketMQTemplate")).isFalse();
+        closeContext();
+
+        load("spring.rocketmq.nameServer=127.0.0.1:9876");
+        assertThat(this.context.containsBean("mqProducer")).isFalse();
+        assertThat(this.context.containsBean("rocketMQTemplate")).isFalse();
+        closeContext();
+
+        load("spring.rocketmq.producer.group=my_group");
+        assertThat(this.context.containsBean("mqProducer")).isFalse();
+        assertThat(this.context.containsBean("rocketMQTemplate")).isFalse();
+        closeContext();
+
+        load("spring.rocketmq.nameServer=127.0.0.1:9876", "spring.rocketmq.producer.group=my_group");
+        assertThat(this.context.containsBean("mqProducer")).isTrue();
+        assertThat(this.context.containsBean("rocketMQTemplate")).isEqualTo(true);
+        assertThat(this.context.getBeansOfType(DefaultRocketMQListenerContainer.class)).isEmpty();
+    }
+
+    @Test
+    public void enableConsumer() {
+        load();
+        assertThat(this.context.getBeansOfType(DefaultRocketMQListenerContainer.class)).isEmpty();
+        closeContext();
+
+        load("spring.rocketmq.nameServer=127.0.0.1:9876");
+        assertThat(this.context.getBeansOfType(DefaultRocketMQListenerContainer.class)).isEmpty();
+        closeContext();
+
+        load(false);
+        this.context.registerBeanDefinition("myListener",
+            BeanDefinitionBuilder.rootBeanDefinition(MyListener.class).getBeanDefinition());
+        this.context.refresh();
+        assertThat(this.context.getBeansOfType(DefaultRocketMQListenerContainer.class)).isEmpty();
+        closeContext();
+
+        load(false, "spring.rocketmq.nameServer=127.0.0.1:9876");
+        this.context.registerBeanDefinition("myListener",
+            BeanDefinitionBuilder.rootBeanDefinition(MyListener.class).getBeanDefinition());
+        this.context.refresh();
+        assertThat(this.context.getBeansOfType(DefaultRocketMQListenerContainer.class)).isNotEmpty();
+        assertThat(this.context.containsBean(DefaultRocketMQListenerContainer.class.getName() + "_1")).isTrue();
+        assertThat(this.context.containsBean("mqProducer")).isFalse();
+        assertThat(this.context.containsBean("rocketMQTemplate")).isFalse();
+
+    }
+
+    @Test
+    public void listenerContainer() {
+        load(false, "spring.rocketmq.nameServer=127.0.0.1:9876");
+        BeanDefinitionBuilder beanBuilder = BeanDefinitionBuilder.rootBeanDefinition(MyListener.class);
+        this.context.registerBeanDefinition("myListener", beanBuilder.getBeanDefinition());
+        this.context.refresh();
+
+        assertThat(this.context.getBeansOfType(DefaultRocketMQListenerContainer.class)).isNotEmpty();
+        assertThat(this.context.containsBean(DefaultRocketMQListenerContainer.class.getName() + "_1")).isTrue();
+
+        DefaultRocketMQListenerContainer listenerContainer =
+            this.context.getBean(DefaultRocketMQListenerContainer.class.getName() + "_1",
+                DefaultRocketMQListenerContainer.class);
+        ObjectMapper objectMapper = this.context.getBean("rocketMQMessageObjectMapper", ObjectMapper.class);
+        assertThat(listenerContainer.getObjectMapper()).isEqualTo(objectMapper);
+        assertThat(listenerContainer.getConsumeMode()).isEqualTo(ConsumeMode.CONCURRENTLY);
+        assertThat(listenerContainer.getSelectorType()).isEqualTo(SelectorType.TAG);
+        assertThat(listenerContainer.getSelectorExpress()).isEqualTo("*");
+        assertThat(listenerContainer.getConsumerGroup()).isEqualTo(TEST_CONSUMER_GROUP);
+        assertThat(listenerContainer.getTopic()).isEqualTo(TEST_TOPIC);
+        assertThat(listenerContainer.getNameServer()).isEqualTo("127.0.0.1:9876");
+        assertThat(listenerContainer.getMessageModel()).isEqualTo(MessageModel.CLUSTERING);
+        assertThat(listenerContainer.getConsumeThreadMax()).isEqualTo(1);
+    }
+
+    @After
+    public void closeContext() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @RocketMQMessageListener(consumerGroup = TEST_CONSUMER_GROUP, topic = TEST_TOPIC, consumeThreadMax = 1)
+    private static class MyListener implements RocketMQListener<String> {
+
+        @Override
+        public void onMessage(String message) {
+            System.out.println(message);
+        }
+    }
+
+    private void load(boolean refresh, String... environment) {
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+        ctx.register(RocketMQAutoConfiguration.class);
+        EnvironmentTestUtils.addEnvironment(ctx, environment);
+        if (refresh) {
+            ctx.refresh();
+        }
+        this.context = ctx;
+    }
+
+    private void load(String... environment) {
+        load(true, environment);
+    }
+}
+

--- a/spring-boot-starter-rocketmq/src/test/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfigurationTests.java
+++ b/spring-boot-starter-rocketmq/src/test/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfigurationTests.java
@@ -34,9 +34,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * RocketMQAutoConfigurationTests Created by aqlu on 2017/10/10.
- */
 public class RocketMQAutoConfigurationTests {
 
     private static final String TEST_CONSUMER_GROUP = "my_consumer";


### PR DESCRIPTION
# What is the purpose of the change

Provider a rocketmq-spring adapter for the convenience of the spring user.
Help developers quickly integrate [RocketMQ](http://rocketmq.apache.org/) in [Spring Boot](http://projects.spring.io/spring-boot/). Support the Spring Message specification to facilitate developers to quickly switch from other MQ to RocketMQ.
JIRA: [https://issues.apache.org/jira/browse/ROCKETMQ-120](https://issues.apache.org/jira/browse/ROCKETMQ-120)

## Brief change log

Features:

- [x] synchronous transmission
- [x] synchronous ordered transmission
- [x] asynchronous transmission
- [x] asynchronous ordered transmission
- [x] orderly consume
- [x] concurrently consume(broadcasting/clustering)
- [x] One-way transmission
- [ ] transaction transmission
- [ ] Pull consume

## Verifying this change

please see: [project readme](https://github.com/aqlu/rocketmq-externals/blob/master/spring-boot-starter-rocketmq/README.md)