### PR TITLE
fixup endless data in MessageSet due to newly created iterator

### DIFF
--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MessageSet.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MessageSet.java
@@ -29,14 +29,16 @@ import java.util.UUID;
  * A message collection.
  */
 public class MessageSet implements Iterator<Message>, Serializable{
-    private String id;
-    private List<MessageExt> data;
+    private final String id;
+    private final List<MessageExt> data;
+    private final Iterator<MessageExt> iterator;
     private long timestamp;
     private int retries;
 
     public MessageSet(String id, List<MessageExt> data) {
         this.id = id;
         this.data = data;
+        this.iterator = data.iterator();
     }
 
     public MessageSet(List<MessageExt> data) {
@@ -69,21 +71,23 @@ public class MessageSet implements Iterator<Message>, Serializable{
 
     @Override
     public boolean hasNext() {
-        return data.iterator().hasNext();
+        return iterator != null && iterator.hasNext();
     }
 
     @Override
     public Message next() {
-        return data.iterator().next();
+        return iterator == null ? null : iterator.next();
     }
 
     @Override
     public void remove() {
-        data.iterator().remove();
+        if (iterator != null) {
+            iterator.remove();
+        }
     }
 
     @Override
     public String toString() {
-        return data.toString();
+        return data == null ? null : data.toString();
     }
 }


### PR DESCRIPTION
bug in MessageSet, newly created iterator will make hasNext() always return true, which will make MessageSet spit endless data items.