### PR TITLE
Change the method name "headExits" to "exists".

### DIFF
--- a/rocketmq-jms/core/src/main/java/org/apache/rocketmq/jms/domain/message/JmsBaseMessage.java
+++ b/rocketmq-jms/core/src/main/java/org/apache/rocketmq/jms/domain/message/JmsBaseMessage.java
@@ -197,7 +197,7 @@ public class JmsBaseMessage implements Message {
     public void copyMetaData(JmsBaseMessage sourceMessage) {
         if (!sourceMessage.getHeaders().isEmpty()) {
             for (Map.Entry<String, Object> entry : sourceMessage.getHeaders().entrySet()) {
-                if (!headerExits(entry.getKey())) {
+                if (!exists(entry.getKey())) {
                     setHeader(entry.getKey(), entry.getValue());
                 }
             }
@@ -238,7 +238,7 @@ public class JmsBaseMessage implements Message {
         ExceptionUtil.handleUnSupportedException();
     }
 
-    public boolean headerExits(String name) {
+    public boolean exists(String name) {
         return this.headers.containsKey(name);
     }
 


### PR DESCRIPTION
The method is checking whether the "name" exists in the "headers" or not, thus the method should be named "exists" but not "headExits".

public boolean headerExits(String name) {	
         return this.headers.containsKey(name);]
}