### PR TITLE
fix docker shell typos

### DIFF
--- a/rocketmq-docker/4.0.0-incubating/play.sh
+++ b/rocketmq-docker/4.0.0-incubating/play.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 sudo docker build -t apache/incubator-rocketmq-namesrv:4.0.0-incubating ./namesrv
 
 sudo docker build -t apache/incubator-rocketmq-broker:4.0.0-incubating ./broker

--- a/rocketmq-docker/4.1.0-incubating/play.sh
+++ b/rocketmq-docker/4.1.0-incubating/play.sh
@@ -1,4 +1,5 @@
-!/bin/bash
+#!/bin/bash
+
 sudo docker build -t apache/incubator-rocketmq-namesrv:4.1.0-incubating ./namesrv
 
 sudo docker build -t apache/incubator-rocketmq-broker:4.1.0-incubating ./broker

--- a/rocketmq-docker/4.1.0-incubating/run.sh
+++ b/rocketmq-docker/4.1.0-incubating/run.sh
@@ -1,2 +1,5 @@
+#!/bin/bash
+
 docker-compose -f docker-compose.yml build
+
 docker-compose -f docker-compose.yml up -d


### PR DESCRIPTION
Signed-off-by: huanwei <huan@harmonycloud.cn>

## What is the purpose of the change

Fix tiny typos on shells in `rocketmq-externals/rocketmq-docker`. 

## Brief changelog

Changes includes:

```
modified:   rocketmq-docker/4.0.0-incubating/play.sh
modified:   rocketmq-docker/4.1.0-incubating/play.sh
modified:   rocketmq-docker/4.1.0-incubating/run.sh
```
## Verifying this change

Run the docker images to verify.
