### PR TITLE
[GSoC Project] RocketMQ HBase Connector

### DIFF
--- a/rocketmq-hbase/README.md
+++ b/rocketmq-hbase/README.md
@@ -1,0 +1,8 @@
+# RocketMQ-HBase
+
+## Overview
+
+This project provides connectors between RocketMQ and HBase. 
+The [HBase sink](rocketmq-hbase-sink) replicates HBase tables to RocketMQ topics, and 
+the [HBase source](rocketmq-hbase-source) replicates RocketMQ topics to HBase tables.
+

--- a/rocketmq-hbase/pom.xml
+++ b/rocketmq-hbase/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache</groupId>
+    <artifactId>rocketmq-hbase</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <modules>
+        <module>rocketmq-hbase-sink</module>
+        <module>rocketmq-hbase-source</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.test.skip>false</maven.test.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <rocketmq.version>4.2.0</rocketmq.version>
+        <hbase.version>1.4.4</hbase.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.rocketmq</groupId>
+            <artifactId>rocketmq-client</artifactId>
+            <version>${rocketmq.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-server</artifactId>
+            <version>${hbase.version}</version>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-testing-util</artifactId>
+            <version>${hbase.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rocketmq</groupId>
+            <artifactId>rocketmq-namesrv</artifactId>
+            <version>${rocketmq.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rocketmq</groupId>
+            <artifactId>rocketmq-broker</artifactId>
+            <version>${rocketmq.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
+                <executions>
+                    <execution>
+                        <id>verify</id>
+                        <phase>verify</phase>
+                        <configuration>
+                            <configLocation>style/rmq_checkstyle.xml</configLocation>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                            <includeTestSourceDirectory>false</includeTestSourceDirectory>
+                            <includeTestResources>false</includeTestResources>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/rocketmq-hbase/rocketmq-hbase-sink/README.md
+++ b/rocketmq-hbase/rocketmq-hbase-sink/README.md
@@ -1,0 +1,35 @@
+# RocketMQ-HBase Sink
+
+## Overview
+
+This project replicates HBase tables to RocketMQ topics.
+
+## Pre-requisites
+- HBase 1.2+
+- JDK 1.8+
+- RocketMQ 4.0.0+ 
+
+## Requirements
+
+- HBase cluster is configured with the setting `hbase.replication` to `true` in hbase-site.xml
+
+## Properties
+Have the below properties set in `hbase-site.xml` and add it to the HBase region server classpath.
+
+|key               |nullable|default    |description|
+|------------------|--------|-----------|-----------|
+|rocketmq.namesrv.addr     |false   |           |RocketMQ name server address (e.g.,127.0.0.1:9876)|
+|rocketmq.topic    |  false |  | RocketMQ topic to replicate HBase data to. | 
+|rocketmq.hbase.tables  |false   |           | List of HBase tables, separated by comma, to replicate to RocketMQ (e.g., table1,table2,table3)|
+
+
+## Deployment
+1. Add rocketmq-hbase-X.Y-SNAPSHOT.jar and hbase-site.xml with the required properties to all the HBase region servers classpath and restart them.
+
+2. At HBase shell, run the following commands.
+
+```bash
+hbase> create 'test', {NAME => 'd', REPLICATION_SCOPE => '1'}
+hbase> add_peer 'rocketmq-repl', ENDPOINT_CLASSNAME => 'org.apache.rocketmq.hbase.Replicator'
+hbase> put 'test', 'r1', 'd', 'value'
+```

--- a/rocketmq-hbase/rocketmq-hbase-sink/pom.xml
+++ b/rocketmq-hbase/rocketmq-hbase-sink/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>rocketmq-hbase</artifactId>
+        <groupId>org.apache</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rocketmq-hbase-sink</artifactId>
+
+
+</project>

--- a/rocketmq-hbase/rocketmq-hbase-sink/src/main/java/org/apache/rocketmq/hbase/sink/DataRow.java
+++ b/rocketmq-hbase/rocketmq-hbase-sink/src/main/java/org/apache/rocketmq/hbase/sink/DataRow.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.hbase.sink;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.groupingBy;
+
+/**
+ * This class represents a HBase data row.
+ */
+public class DataRow {
+    private static final Logger logger = LoggerFactory.getLogger(DataRow.class);
+
+    private String type;
+
+    private String table;
+
+    private byte[] row;
+
+    private List<Cell> cells;
+
+    /**
+     * Constructor.
+     *
+     * @param type the type of operation, put or delete
+     * @param table the table
+     * @param row the row key
+     * @param cells the cells
+     */
+    public DataRow(String type, String table, byte[] row, List<Cell> cells) {
+        this.type = type;
+        this.table = table;
+        this.row = row;
+        this.cells = cells;
+    }
+
+    /**
+     * Converts this data row to a map.
+     *
+     * @return a map structure containing a representation of this row
+     */
+    public Map<String, Object> toMap() {
+        final Map<String, Object> dataMap = new HashMap<>();
+
+        final Map<byte[], List<Cell>> columnsByFamily = cells.stream().collect(groupingBy(CellUtil::cloneFamily));
+
+        for(Map.Entry<byte[], List<Cell>> entry : columnsByFamily.entrySet()) {
+            final String columnFamily = Bytes.toString(entry.getKey());
+            final List<Cell> cells = entry.getValue();
+
+            final Map<String, Object> qualifiers = new HashMap<>();
+            for (Cell cell : cells) {
+                if (cell.getQualifierLength() > 0) {
+                    final String columnQualifier = Bytes.toString(CellUtil.cloneQualifier(cell));
+                    qualifiers.put(columnQualifier, CellUtil.cloneValue(cell));
+                } else {
+                    dataMap.put(columnFamily, CellUtil.cloneValue(cell));
+                }
+            }
+            if (qualifiers.size() > 0) {
+                dataMap.put(columnFamily, qualifiers);
+            }
+        }
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("table", table);
+        map.put("type", type);
+        map.put("row", Bytes.toString(row));
+        map.put("data", dataMap);
+
+        return map;
+    }
+}

--- a/rocketmq-hbase/rocketmq-hbase-sink/src/main/java/org/apache/rocketmq/hbase/sink/Replicator.java
+++ b/rocketmq-hbase/rocketmq-hbase-sink/src/main/java/org/apache/rocketmq/hbase/sink/Replicator.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.hbase.sink;
+
+import com.google.common.collect.Sets;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.replication.BaseReplicationEndpoint;
+import org.apache.hadoop.hbase.wal.WAL;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static java.util.stream.Collectors.groupingBy;
+
+/**
+ * This class functions as an HBase replication endpoint, that runs at each region server,
+ * and replicates data from specified HBase tables to a RocketMQ topic.
+ */
+public class Replicator extends BaseReplicationEndpoint {
+
+    private static final String ROCKETMQ_NAMESRV_ADDR_PARAM = "rocketmq.namesrv.addr";
+
+    private static final String ROCKETMQ_TOPIC_PARAM = "rocketmq.topic";
+
+    private static final String ROCKETMQ_HBASE_TABLES_PARAM = "rocketmq.hbase.tables";
+
+    private static final String ROCKETMQ_TRANSACTION_ROWS_PARAM = "rocketmq.transaction.max.rows";
+
+    private static final int ROCKETMQ_TRANSACTION_ROWS_DEFAULT = 100;
+
+    private static final Logger logger = LoggerFactory.getLogger(Replicator.class);
+
+    private RocketMQProducer producer;
+
+    private Set<String> tables = Sets.newHashSet();
+
+    private int maxTransactionRows;
+
+    /**
+     * Constructor.
+     */
+    public Replicator() {
+        super();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(Context context) throws IOException {
+        super.init(context);
+        logger.info("HBaseEndpoint initialized");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doStart() {
+        final Configuration config = ctx.getConfiguration();
+        final String namesrvAddr = config.get(ROCKETMQ_NAMESRV_ADDR_PARAM);
+        if (namesrvAddr == null) {
+            logger.error("Configuration property not set: " + ROCKETMQ_NAMESRV_ADDR_PARAM);
+            return;
+        }
+
+        final String topic = config.get(ROCKETMQ_TOPIC_PARAM);
+        if (topic == null) {
+            logger.error("Configuration property not set: " + ROCKETMQ_TOPIC_PARAM);
+            return;
+        }
+
+        final String tablesParam = config.get(ROCKETMQ_HBASE_TABLES_PARAM);
+        if (tablesParam == null) {
+            logger.error("Configuration property not set: " + ROCKETMQ_HBASE_TABLES_PARAM);
+            return;
+        }
+        tables = new HashSet<>(Arrays.asList(tablesParam.split(",")));
+
+        maxTransactionRows = config.getInt(ROCKETMQ_TRANSACTION_ROWS_PARAM, ROCKETMQ_TRANSACTION_ROWS_DEFAULT);
+
+        try {
+            producer = new RocketMQProducer(namesrvAddr, topic);
+            producer.start();
+
+            logger.info("HBase replication to RocketMQ started");
+            notifyStarted();
+        } catch (MQClientException e) {
+            logger.error("Failed to start RocketMQ producer.", e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doStop() {
+        producer.stop();
+
+        logger.info("HBase replication to RocketMQ stopped.");
+        notifyStopped();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UUID getPeerUUID() {
+        return UUID.randomUUID();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean replicate(ReplicateContext context) {
+        final List<WAL.Entry> entries = context.getEntries();
+
+        final Map<String, List<WAL.Entry>> entriesByTable = entries.stream()
+                .filter(entry -> tables.contains(entry.getKey().getTablename().getNameAsString()))
+                .collect(groupingBy(entry -> entry.getKey().getTablename().getNameAsString()));
+
+        // replicate data to rocketmq
+        Transaction transaction = new Transaction(maxTransactionRows);
+        try {
+            for (Map.Entry<String, List<WAL.Entry>> entry : entriesByTable.entrySet()) {
+                final String tableName = entry.getKey();
+                final List<WAL.Entry> tableEntries = entry.getValue();
+
+                for (WAL.Entry tableEntry : tableEntries) {
+                    List<Cell> cells = tableEntry.getEdit().getCells();
+
+                    // group entries by the row key
+                    Map<byte[], List<Cell>> columnsByRow = cells.stream().collect(groupingBy(CellUtil::cloneRow));
+
+                    for (Map.Entry<byte[], List<Cell>> rowCols : columnsByRow.entrySet()) {
+                        final byte[] row = rowCols.getKey();
+                        final List<Cell> columns = rowCols.getValue();
+
+                        if (!transaction.addRow(tableName, row, columns)) {
+                            producer.push(transaction.toJson());
+                            transaction = new Transaction(maxTransactionRows);
+                        }
+                    }
+                }
+            }
+
+            // replicate remaining transaction
+            producer.push(transaction.toJson());
+        } catch (Exception e) {
+            logger.error("Error while sending message to RocketMQ.", e);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/rocketmq-hbase/rocketmq-hbase-sink/src/main/java/org/apache/rocketmq/hbase/sink/RocketMQProducer.java
+++ b/rocketmq-hbase/rocketmq-hbase-sink/src/main/java/org/apache/rocketmq/hbase/sink/RocketMQProducer.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.hbase.sink;
+
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.common.message.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class represents the RocketMQ producer that effectively pushes the messages to the RocketMQ server.
+ */
+public class RocketMQProducer {
+    private static final String PRODUCER_GROUP_NAME = "HBASE_PRODUCER_GROUP";
+
+    private static final Logger logger = LoggerFactory.getLogger(RocketMQProducer.class);
+
+    private DefaultMQProducer producer;
+
+    private String namesrvAddr;
+
+    private String topic;
+
+    /**
+     * Constructor.
+     *
+     * @param namesrvAddr the nameserver address
+     * @param topic the topic to write to
+     */
+    public RocketMQProducer(String namesrvAddr, String topic) {
+        this.namesrvAddr = namesrvAddr;
+        this.topic = topic;
+    }
+
+    /**
+     * Starts the producer.
+     *
+     * @throws MQClientException
+     */
+    public void start() throws MQClientException {
+        producer = new DefaultMQProducer(PRODUCER_GROUP_NAME);
+        producer.setInstanceName("producer-" + System.currentTimeMillis());
+        producer.setNamesrvAddr(namesrvAddr);
+        producer.start();
+    }
+
+    /**
+     * Pushes messages to the RocketMQ server.
+     *
+     * @param json the message to be sent in json format
+     * @return the result status code
+     * @throws Exception
+     */
+    public long push(String json) throws Exception {
+        logger.debug(json);
+
+        Message message = new Message(topic, json.getBytes("UTF-8"));
+        SendResult sendResult = producer.send(message);
+
+        return sendResult.getQueueOffset();
+    }
+
+    /**
+     * Stops the RocketMQ producer.
+     */
+    public void stop() {
+        producer.shutdown();
+    }
+}

--- a/rocketmq-hbase/rocketmq-hbase-sink/src/main/java/org/apache/rocketmq/hbase/sink/Transaction.java
+++ b/rocketmq-hbase/rocketmq-hbase-sink/src/main/java/org/apache/rocketmq/hbase/sink/Transaction.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.hbase.sink;
+
+import com.alibaba.fastjson.JSONObject;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.protobuf.generated.CellProtos;
+
+/**
+ * This class represents a transaction that contains a fixed amount of HBase rows that are to be pushed together to
+ * RocketMQ.
+ */
+public class Transaction {
+
+    private final int maxTransactionRows;
+
+    private List<DataRow> rows = new LinkedList<>();
+
+    /**
+     * Constructor.
+     *
+     * @param maxTransactionRows number of maximum rows supported by this transaction
+     */
+    public Transaction(int maxTransactionRows) {
+        this.maxTransactionRows = maxTransactionRows;
+    }
+
+    /**
+     * Adds a row to this transaction.
+     *
+     * @param tableName the name of the HBase table
+     * @param rowKey the row key
+     * @param cells the cells
+     * @return true if more rows can be added to this transaction; false otherwise.
+     */
+    public boolean addRow(String tableName, byte[] rowKey, List<Cell> cells) {
+
+        final Cell cell = cells.get(0);
+        final CellProtos.CellType type = CellProtos.CellType.valueOf(cell.getTypeByte());
+        final String typeStr;
+        switch (type) {
+            case DELETE:
+                typeStr = "DELETE";
+                break;
+            case DELETE_COLUMN:
+                typeStr = "DELETE_COLUMN";
+                break;
+            case DELETE_FAMILY:
+                typeStr = "DELETE_FAMILY";
+                break;
+            case PUT:
+                typeStr = "PUT";
+                break;
+            default:
+                typeStr = null;
+        }
+
+        DataRow dataRow = new DataRow(typeStr, tableName, rowKey, cells);
+        rows.add(dataRow);
+
+        return rows.size() < maxTransactionRows;
+    }
+
+//    private void toRowColumns(final List<Cell> cells) {
+//
+////        cells.stream().map(cell -> {
+////            byte[] family = CellUtil.cloneFamily(cell);
+////            byte[] qualifier = CellUtil.cloneQualifier(cell);
+////            byte[] value = CellUtil.cloneValue(cell);
+////            long timestamp = cell.getTimestamp();
+////
+////            final HRow.HColumn column = new HRow.HColumn(family, qualifier, value, timestamp);
+////            return column;
+////        }).collect(toList());
+////
+////        return columns;
+//    }
+
+    /**
+     * Converts this transaction to json.
+     *
+     * @return a string with the json representation of this transaction
+     */
+    public String toJson() {
+        Map<String, Object> map = new HashMap<>();
+        List<Map<String, Object>> rowsMap = rows.stream().map(row -> row.toMap()).collect(Collectors.toList());
+        map.put("rows", rowsMap);
+
+        return JSONObject.toJSONString(map);
+    }
+}

--- a/rocketmq-hbase/rocketmq-hbase-sink/src/test/java/org/apache/rocketmq/sink/ReplicatorTest.java
+++ b/rocketmq-hbase/rocketmq-hbase-sink/src/test/java/org/apache/rocketmq/sink/ReplicatorTest.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.sink;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.replication.ReplicationAdmin;
+import org.apache.hadoop.hbase.replication.ReplicationException;
+import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
+import org.apache.hadoop.hbase.zookeeper.ZKConfig;
+import org.apache.rocketmq.broker.BrokerController;
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.PullStatus;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.BrokerConfig;
+import org.apache.rocketmq.common.MQVersion;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.namesrv.NamesrvConfig;
+import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
+import org.apache.rocketmq.hbase.sink.Replicator;
+import org.apache.rocketmq.hbase.sink.Transaction;
+import org.apache.rocketmq.namesrv.NamesrvController;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+import org.apache.rocketmq.remoting.netty.NettyClientConfig;
+import org.apache.rocketmq.remoting.netty.NettyServerConfig;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.hadoop.hbase.util.Bytes.toBytes;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This class tests the replicator by writing data from hbase to rocketmq and reading it back.
+ */
+public class ReplicatorTest {
+
+    private static final String CONSUMER_GROUP_NAME = "HBASE_CONSUMER_GROUP_TEST";
+
+    private static final String ROCKETMQ_TOPIC = "rocketmq-hbase-topic-test";
+
+    private static final String NAMESERVER = "localhost:9876";
+
+    private static final String TABLE_NAME_STR = "hbase-rocketmq-test";
+
+    private static final String PEER_NAME = "rocketmq.hbase";
+
+    private final TableName TABLE_NAME = TableName.valueOf(TABLE_NAME_STR);
+    private final String ROWKEY = "rk-%s";
+    private final String COLUMN_FAMILY = "d";
+    private final String QUALIFIER = "q";
+    private final String VALUE = "v";
+
+    private static final Logger logger = LoggerFactory.getLogger(ReplicatorTest.class);
+
+    private static NamesrvController namesrvController;
+
+    private static BrokerController brokerController;
+
+    private HBaseTestingUtility utility;
+
+    private int numRegionServers;
+
+    private int batchSize = 100;
+
+    /**
+     * This method starts the HBase cluster and the RocketMQ server.
+     *
+     * @throws Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        final Configuration hbaseConf = HBaseConfiguration.create();
+        hbaseConf.setInt("replication.stats.thread.period.seconds", 5);
+        hbaseConf.setLong("replication.sleep.before.failover", 2000);
+        hbaseConf.setInt("replication.source.maxretriesmultiplier", 10);
+        hbaseConf.setBoolean(HConstants.REPLICATION_ENABLE_KEY, true);
+
+        // Add RocketMQ properties - we prefix each property with 'rocketmq'
+        addRocketMQProperties(hbaseConf);
+
+        utility = new HBaseTestingUtility(hbaseConf);
+        utility.startMiniCluster();
+        utility.getHBaseCluster().getRegionServerThreads().size();
+
+        // setup and start RocketMQ
+        startMQ();
+    }
+
+    /**
+     * Add RocketMQ properties to {@link Configuration}
+     *
+     * @param hbaseConf
+     */
+    private void addRocketMQProperties(Configuration hbaseConf) {
+        hbaseConf.set("rocketmq.namesrv.addr", NAMESERVER);
+        hbaseConf.set("rocketmq.topic", ROCKETMQ_TOPIC);
+        hbaseConf.set("rocketmq.hbase.tables", TABLE_NAME_STR);
+    }
+
+    /**
+     * @param configuration
+     * @param peerName
+     * @param tableCFs
+     * @throws ReplicationException
+     * @throws IOException
+     */
+    private void addPeer(final Configuration configuration, String peerName, Map<TableName, List<String>> tableCFs)
+        throws ReplicationException, IOException {
+        try (ReplicationAdmin replicationAdmin = new ReplicationAdmin(configuration)) {
+            ReplicationPeerConfig peerConfig = new ReplicationPeerConfig()
+                .setClusterKey(ZKConfig.getZooKeeperClusterKey(configuration))
+                .setReplicationEndpointImpl(Replicator.class.getName());
+
+            replicationAdmin.addPeer(peerName, peerConfig, tableCFs);
+        }
+    }
+
+    /**
+     * This method starts the RocketMQ server.
+     *
+     * @throws Exception
+     */
+    private static void startMQ() throws Exception {
+        startNamesrv();
+        startBroker();
+
+        Thread.sleep(2000);
+    }
+
+    /**
+     * This method starts the RocketMQ nameserver.
+     *
+     * @throws Exception
+     */
+    private static void startNamesrv() throws Exception {
+
+        final NamesrvConfig namesrvConfig = new NamesrvConfig();
+        NettyServerConfig nettyServerConfig = new NettyServerConfig();
+        nettyServerConfig.setListenPort(9876);
+
+        namesrvController = new NamesrvController(namesrvConfig, nettyServerConfig);
+        final boolean initResult = namesrvController.initialize();
+        if (!initResult) {
+            namesrvController.shutdown();
+            throw new Exception("Name server controller failed to initialize.");
+        }
+        namesrvController.start();
+    }
+
+    /**
+     * This method starts the RocketMQ broker.
+     *
+     * @throws Exception
+     */
+    private static void startBroker() throws Exception {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, Integer.toString(MQVersion.CURRENT_VERSION));
+
+        final BrokerConfig brokerConfig = new BrokerConfig();
+        brokerConfig.setNamesrvAddr(NAMESERVER);
+        brokerConfig.setBrokerId(MixAll.MASTER_ID);
+        final NettyServerConfig nettyServerConfig = new NettyServerConfig();
+        nettyServerConfig.setListenPort(10911);
+        final NettyClientConfig nettyClientConfig = new NettyClientConfig();
+        final MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+
+        brokerController = new BrokerController(brokerConfig, nettyServerConfig, nettyClientConfig, messageStoreConfig);
+        boolean initResult = brokerController.initialize();
+        if (!initResult) {
+            brokerController.shutdown();
+            throw new Exception();
+        }
+        brokerController.start();
+    }
+
+    /**
+     * This method tests the replicator by writing data from hbase to rocketmq and reading it back.
+     *
+     * @throws IOException
+     * @throws ReplicationException
+     * @throws InterruptedException
+     * @throws MQClientException
+     * @throws RemotingException
+     * @throws MQBrokerException
+     */
+    @Test
+    public void testCustomReplicationEndpoint() throws IOException, ReplicationException, InterruptedException,
+        MQClientException, RemotingException, MQBrokerException {
+
+        final DefaultMQPullConsumer consumer = new DefaultMQPullConsumer(CONSUMER_GROUP_NAME);
+        try {
+            createTestTable();
+
+            final Map<TableName, List<String>> tableCfs = new HashMap<>();
+            List<String> cfs = new ArrayList<>();
+            cfs.add(COLUMN_FAMILY);
+            tableCfs.put(TABLE_NAME, cfs);
+            addPeer(utility.getConfiguration(), PEER_NAME, tableCfs);
+
+            // wait for new peer to be added
+            Thread.sleep(500);
+
+            final int numberOfRecords = 10;
+            final Transaction inTransaction = insertData(numberOfRecords);
+
+            // wait for data to be replicated
+            Thread.sleep(500);
+
+            consumer.setNamesrvAddr(NAMESERVER);
+            consumer.setMessageModel(MessageModel.valueOf("BROADCASTING"));
+            consumer.registerMessageQueueListener(ROCKETMQ_TOPIC, null);
+            consumer.start();
+
+            int receiveNum = 0;
+            String receiveMsg = null;
+            Set<MessageQueue> queues = consumer.fetchSubscribeMessageQueues(ROCKETMQ_TOPIC);
+            for (MessageQueue queue : queues) {
+                long offset = getMessageQueueOffset(consumer, queue);
+                PullResult pullResult = consumer.pull(queue, null, offset, batchSize);
+
+                if (pullResult.getPullStatus() == PullStatus.FOUND) {
+                    for (MessageExt message : pullResult.getMsgFoundList()) {
+                        byte[] body = message.getBody();
+                        receiveMsg = new String(body, "UTF-8");
+                        // String[] receiveMsgKv = receiveMsg.split(",");
+                        // msgs.remove(receiveMsgKv[1]);
+                        logger.info("receive message : {}", receiveMsg);
+                        receiveNum++;
+                    }
+                    long nextBeginOffset = pullResult.getNextBeginOffset();
+                    consumer.updateConsumeOffset(queue, offset);
+                }
+            }
+            logger.info("receive message num={}", receiveNum);
+
+            // wait for processQueueTable init
+            Thread.sleep(1000);
+
+            assertEquals(inTransaction.toJson(), receiveMsg);
+        } finally {
+            removePeer();
+            consumer.shutdown();
+        }
+    }
+
+    /**
+     * Gets the message queue offset.
+     *
+     * @param consumer the rocketmq consumer
+     * @param queue the queue from where to consume the message
+     * @return the offset
+     * @throws MQClientException
+     */
+    private long getMessageQueueOffset(DefaultMQPullConsumer consumer, MessageQueue queue) throws MQClientException {
+        long offset = consumer.fetchConsumeOffset(queue, false);
+        if (offset < 0) {
+            offset = 0;
+        }
+        return offset;
+    }
+
+    /**
+     * Creates the HBase table with a scope set to global.
+     *
+     * @throws IOException
+     */
+    private void createTestTable() throws IOException {
+        try (HBaseAdmin hBaseAdmin = utility.getHBaseAdmin()) {
+            final HTableDescriptor hTableDescriptor = new HTableDescriptor(TABLE_NAME);
+            final HColumnDescriptor hColumnDescriptor = new HColumnDescriptor(COLUMN_FAMILY);
+            hColumnDescriptor.setScope(HConstants.REPLICATION_SCOPE_GLOBAL);
+            hTableDescriptor.addFamily(hColumnDescriptor);
+            hBaseAdmin.createTable(hTableDescriptor);
+        }
+        utility.waitUntilAllRegionsAssigned(TABLE_NAME);
+    }
+
+    /**
+     * Adds data to the previously created HBase table.
+     *
+     * @throws IOException
+     */
+    private Transaction insertData(int numberOfRecords) throws IOException {
+        final Transaction transaction = new Transaction(numberOfRecords);
+        try (Table hTable = ConnectionFactory.createConnection(utility.getConfiguration()).getTable(TABLE_NAME)) {
+            for (int i = 0; i < numberOfRecords; i++) {
+                final byte[] rowKey = toBytes(String.format(ROWKEY, i));
+                final byte[] family = toBytes(COLUMN_FAMILY);
+                final Put put = new Put(rowKey);
+                put.addColumn(family, toBytes(QUALIFIER), toBytes(VALUE));
+                hTable.put(put);
+
+                List<Cell> cells = put.getFamilyCellMap().get(family);
+                transaction.addRow(TABLE_NAME_STR, rowKey, cells);
+            }
+        }
+        return transaction;
+    }
+
+    /**
+     * Removes the HBase peer.
+     *
+     * @throws IOException
+     * @throws ReplicationException
+     */
+    private void removePeer() throws IOException, ReplicationException {
+        try (ReplicationAdmin replicationAdmin = new ReplicationAdmin(utility.getConfiguration())) {
+            replicationAdmin.removePeer(PEER_NAME);
+        }
+    }
+
+    /**
+     * Shuts down the HBase cluster and the RocketMQ server.
+     *
+     * @throws Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+        if (utility != null) {
+            utility.shutdownMiniCluster();
+        }
+
+        if (brokerController != null) {
+            brokerController.shutdown();
+        }
+
+        if (namesrvController != null) {
+            namesrvController.shutdown();
+        }
+    }
+}

--- a/rocketmq-hbase/rocketmq-hbase-source/LICENSE-BIN
+++ b/rocketmq-hbase/rocketmq-hbase-source/LICENSE-BIN
@@ -1,0 +1,301 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+------
+This product has a bundle logback, which is available under the EPL v1.0 License.
+The source code of logback can be found at https://github.com/qos-ch/logback.
+
+Logback LICENSE
+---------------
+
+Logback: the reliable, generic, fast and flexible logging framework.
+Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+
+This program and the accompanying materials are dual-licensed under
+either the terms of the Eclipse Public License v1.0 as published by
+the Eclipse Foundation
+
+  or (per the licensee's choosing)
+
+under the terms of the GNU Lesser General Public License version 2.1
+as published by the Free Software Foundation.
+
+------
+This product has a bundle slf4j, which is available under the MIT License.
+The source code of slf4j can be found at https://github.com/qos-ch/slf4j.
+
+ Copyright (c) 2004-2017 QOS.ch
+ All rights reserved.
+
+ Permission is hereby granted, free  of charge, to any person obtaining
+ a  copy  of this  software  and  associated  documentation files  (the
+ "Software"), to  deal in  the Software without  restriction, including
+ without limitation  the rights to  use, copy, modify,  merge, publish,
+ distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ permit persons to whom the Software  is furnished to do so, subject to
+ the following conditions:
+
+ The  above  copyright  notice  and  this permission  notice  shall  be
+ included in all copies or substantial portions of the Software.
+
+ THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------
+This product has a bundle fastjson, which is available under the ASL2 License.
+The source code of fastjson can be found at https://github.com/alibaba/fastjson.
+
+ Copyright 1999-2017 Alibaba Group Holding Ltd.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+------
+ This product has a bundle druid, which is available under the ASL2 License.
+ The source code of druid can be found at https://github.com/alibaba/druid.
+
+  Copyright 1999-2017 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+------
+This product has a bundle commons-codec, which is available under the ASL2 License.
+The source code of commons-codec can be found at http://svn.apache.org/viewvc/commons/proper/codec/trunk/.
+
+Apache Commons Codec
+Copyright 2002-2016 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
+contains test data from http://aspell.net/test/orig/batch0.tab.
+Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
+
+------
+This product has a bundle mysql-binlog-connector-java, which is available under the ASL2 License.
+The source code of mysql-binlog-connector-java can be found at https://github.com/shyiko/mysql-binlog-connector-java.

--- a/rocketmq-hbase/rocketmq-hbase-source/NOTICE-BIN
+++ b/rocketmq-hbase/rocketmq-hbase-source/NOTICE-BIN
@@ -1,0 +1,5 @@
+Apache RocketMQ (incubating)
+Copyright 2016-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/rocketmq-hbase/rocketmq-hbase-source/README.md
+++ b/rocketmq-hbase/rocketmq-hbase-source/README.md
@@ -1,0 +1,30 @@
+# RocketMQ-HBase Source
+
+## Overview
+
+This project replicates RocketMQ topics to HBase tables.
+
+## Pre-requisites
+- HBase 1.2+
+- JDK 1.8+
+- RocketMQ 4.0.0+ 
+
+## Assumptions
+
+- Each specified RocketMQ topic is mapped to a HBase table with the same name
+- The HBase tables already exist
+
+## Properties
+
+Have the below properties set in `rocketmq_hbase.conf`
+
+|key               |nullable|default    |description|
+|------------------|--------|-----------|-----------|
+| topics    |  false |  | A comma separated list of RocketMQ topics to replicate to HBase (e.g., topic1,topic2,topic3) |
+| nameserver     |true   |  localhost:9876   |RocketMQ name server address |
+| consumerGroup | true     |HBASE_CONSUMER_GROUP| The consumer group name|
+| messageModel  | true     | BROADCASTING       |RocketMQ message model, 'BROADCASTING' or 'CLUSTERING'|
+| zookeeperAddress | true | localhost | A comma separated list of the IP addresses of all ZooKeeper servers in the cluster |
+| zookeeperPort | true | 2181 | The port at which the clients will connect | 
+| batchSize     | true     | 32                   | The maximum number of messages to be consumed in batch from RocketMQ|
+| pullInterval | true | 1000 | Time in milliseconds to wait between consecutive pulls |

--- a/rocketmq-hbase/rocketmq-hbase-source/pom.xml
+++ b/rocketmq-hbase/rocketmq-hbase-source/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>rocketmq-hbase</artifactId>
+        <groupId>org.apache</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rocketmq-hbase-source</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                        </manifest>
+                    </archive>
+                    <excludes>
+                        <exclude>rocketmq_hbase.conf</exclude>
+                        <exclude>logback.xml</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/rocketmq-hbase/rocketmq-hbase-source/src/main/assembly/assembly.xml
+++ b/rocketmq-hbase/rocketmq-hbase-source/src/main/assembly/assembly.xml
@@ -1,0 +1,61 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>pack</id>
+    <formats>
+        <format>tar.gz</format>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>true</useProjectArtifact>
+            <outputDirectory>lib</outputDirectory>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>src/main/assembly/scripts</directory>
+            <outputDirectory>bin</outputDirectory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>target/classes</directory>
+            <outputDirectory>conf</outputDirectory>
+            <fileMode>0755</fileMode>
+            <includes>
+                <include>*.conf</include>
+                <include>logback.xml</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+
+    <files>
+        <file>
+            <source>LICENSE-BIN</source>
+            <destName>LICENSE</destName>
+        </file>
+        <file>
+            <source>NOTICE-BIN</source>
+            <destName>NOTICE</destName>
+        </file>
+    </files>
+</assembly>

--- a/rocketmq-hbase/rocketmq-hbase-source/src/main/assembly/scripts/start.sh
+++ b/rocketmq-hbase/rocketmq-hbase-source/src/main/assembly/scripts/start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+binPath=$(cd "$(dirname "$0")"; pwd);
+cd $binPath
+cd ..
+parentPath=`pwd`
+libPath=$parentPath/lib/
+
+
+function exportClassPath(){
+    jarFileList=`find "$libPath" -name *.jar |awk -F'/' '{print $(NF)}' 2>>/dev/null`
+    CLASSPATH=".:$binPath";
+    for jarItem in $jarFileList
+      do
+        CLASSPATH="$CLASSPATH:$libPath$jarItem"
+    done
+    CLASSPATH=$CLASSPATH:./conf
+    export CLASSPATH
+}
+exportClassPath
+
+java -server -Xms512m -Xmx512m -Xss2m -XX:NewRatio=2  -XX:+UseGCOverheadLimit -XX:-UseParallelGC -XX:ParallelGCThreads=24 org.apache.rocketmq.hbase.source.RocketMQSource

--- a/rocketmq-hbase/rocketmq-hbase-source/src/main/assembly/scripts/stop.sh
+++ b/rocketmq-hbase/rocketmq-hbase-source/src/main/assembly/scripts/stop.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+PROGRAM_NAME="org.apache.rocketmq.hbase.source.RocketMQSource"
+PIDS=`ps -ef | grep $PROGRAM_NAME | grep -v "grep" | awk '{print $2}'`
+
+if [ -z $PIDS ]; then
+    echo "$PROGRAM_NAME is not running."
+else
+    echo "$PROGRAM_NAME pids are $PIDS."
+fi
+
+#####kill####
+echo -e "Stopping the $PROGRAM_NAME...\c"
+for PID in $PIDS ; do
+    kill  $PID
+done
+
+echo "SUCCESS!"

--- a/rocketmq-hbase/rocketmq-hbase-source/src/main/java/org/apache/rocketmq/hbase/source/Config.java
+++ b/rocketmq-hbase/rocketmq-hbase-source/src/main/java/org/apache/rocketmq/hbase/source/Config.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.hbase.source;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Config is a convenience class that maintains all configuration properties that are needed for the application.
+ */
+public class Config {
+
+    private static final String TOPICS_SEPARATOR = ",";
+
+    private String nameserver = "localhost:9876";
+
+    private String consumerGroup = "HBASE_CONSUMER_GROUP";
+
+    private String messageModel = "BROADCASTING";
+
+    private String topics;
+
+    private String zookeeperAddress = "localhost";
+
+    private int zookeeperPort = 2181;
+
+    private long pullInterval = 1000;
+
+    private int batchSize = 32;
+
+    /**
+     * Loads all properties from the configuration file.
+     *
+     * @throws IOException
+     */
+    public void load() throws IOException {
+        InputStream in = Config.class.getClassLoader().getResourceAsStream("rocketmq_hbase.conf");
+        Properties properties = new Properties();
+        properties.load(in);
+
+        properties2Object(properties, this);
+    }
+
+    /**
+     * Populate class fields with properties.
+     *
+     * @param p the properties instance
+     * @param object this class instance
+     */
+    private void properties2Object(final Properties p, final Object object) {
+        Method[] methods = object.getClass().getMethods();
+        for (Method method : methods) {
+            String mn = method.getName();
+            if (mn.startsWith("set")) {
+                try {
+                    String tmp = mn.substring(4);
+                    String first = mn.substring(3, 4);
+
+                    String key = first.toLowerCase() + tmp;
+                    String property = p.getProperty(key);
+                    if (property != null) {
+                        Class<?>[] pt = method.getParameterTypes();
+                        if (pt != null && pt.length > 0) {
+                            String cn = pt[0].getSimpleName();
+                            Object arg;
+                            if (cn.equals("int") || cn.equals("Integer")) {
+                                arg = Integer.parseInt(property);
+                            } else if (cn.equals("long") || cn.equals("Long")) {
+                                arg = Long.parseLong(property);
+                            } else if (cn.equals("double") || cn.equals("Double")) {
+                                arg = Double.parseDouble(property);
+                            } else if (cn.equals("boolean") || cn.equals("Boolean")) {
+                                arg = Boolean.parseBoolean(property);
+                            } else if (cn.equals("float") || cn.equals("Float")) {
+                                arg = Float.parseFloat(property);
+                            } else if (cn.equals("String")) {
+                                arg = property;
+                            } else {
+                                continue;
+                            }
+                            method.invoke(object, arg);
+                        }
+                    }
+                } catch (Throwable ignored) {
+                }
+            }
+        }
+    }
+
+    public String getNameserver() {
+        return nameserver;
+    }
+
+    public String getConsumerGroup() {
+        return consumerGroup;
+    }
+
+    public String getMessageModel() {
+        return messageModel;
+    }
+
+    public Set<String> getTopics() {
+        final String[] topicsArr = topics.split(TOPICS_SEPARATOR);
+        final Set<String> topicsSet = new HashSet<>();
+        Collections.addAll(topicsSet, topicsArr);
+        return topicsSet;
+    }
+
+    public String getZookeeperAddress() {
+        return zookeeperAddress;
+    }
+
+    public int getZookeeperPort() {
+        return zookeeperPort;
+    }
+
+    public long getPullInterval() {
+        return pullInterval;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setNameserver(String nameserver) {
+        this.nameserver = nameserver;
+    }
+
+    public void setConsumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
+    }
+
+    public void setMessageModel(String messageModel) {
+        this.messageModel = messageModel;
+    }
+
+    public void setTopics(String topics) {
+        this.topics = topics;
+    }
+
+    public void setZookeeperAddress(String zookeeperAddress) {
+        this.zookeeperAddress = zookeeperAddress;
+    }
+
+    public void setZookeeperPort(int zookeeperPort) {
+        this.zookeeperPort = zookeeperPort;
+    }
+
+    public void setPullInterval(long pullInterval) {
+        this.pullInterval = pullInterval;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+}

--- a/rocketmq-hbase/rocketmq-hbase-source/src/main/java/org/apache/rocketmq/hbase/source/HBaseClient.java
+++ b/rocketmq-hbase/rocketmq-hbase-source/src/main/java/org/apache/rocketmq/hbase/source/HBaseClient.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.hbase.source;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hbase.util.Bytes.toBytes;
+
+/**
+ * This class represents the HBase client that effectively writes the messages to the corresponding HBase tables.
+ */
+public class HBaseClient {
+
+    public static final byte[] COLUMN_FAMILY = toBytes("message");
+
+    private static final Logger logger = LoggerFactory.getLogger(HBaseClient.class);
+
+    private String zookeeperAddress;
+
+    private int zookeeperPort;
+
+    private Connection connection;
+
+    /**
+     * Constructor.
+     *
+     * @param config the configuration
+     */
+    public HBaseClient(Config config) {
+        this.zookeeperAddress = config.getZookeeperAddress();
+        this.zookeeperPort = config.getZookeeperPort();
+    }
+
+    /**
+     * Starts the HBase client by opening a connection to the HBase server.
+     *
+     * @throws IOException
+     */
+    public void start() throws IOException {
+        final Configuration hbaseConfig = HBaseConfiguration.create();
+        hbaseConfig.set("hbase.zookeeper.quorum", zookeeperAddress);
+        hbaseConfig.set("hbase.zookeeper.property.clientPort", Integer.toString(zookeeperPort));
+        connection = ConnectionFactory.createConnection(hbaseConfig);
+        logger.info("HBase client started.");
+    }
+
+    /**
+     * Writes messages into a specified HBase table.
+     *
+     * @param tableName
+     * @param messages
+     * @throws IOException
+     */
+    public void put(String tableName, List<MessageExt> messages) throws IOException {
+
+        try (Table table = connection.getTable(TableName.valueOf(tableName))) {
+            final List<Put> puts = new ArrayList<>();
+
+            for (MessageExt msg : messages) {
+                final Put put = new Put(toBytes(msg.getMsgId()));
+                put.addColumn(COLUMN_FAMILY, null, msg.getBody());
+                puts.add(put);
+            }
+
+            table.put(puts);
+        }
+    }
+
+    /**
+     * Stops the HBase client.
+     *
+     * @throws IOException
+     */
+    public void stop() throws IOException {
+        connection.close();
+        logger.info("HBase client stopped.");
+    }
+}

--- a/rocketmq-hbase/rocketmq-hbase-source/src/main/java/org/apache/rocketmq/hbase/source/MessageProcessor.java
+++ b/rocketmq-hbase/rocketmq-hbase-source/src/main/java/org/apache/rocketmq/hbase/source/MessageProcessor.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.hbase.source;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * MessageProcessor is the main class that is responsible for managing the main work flow of pulling messages from
+ * RocketMQ topics and writing them into HBase.
+ */
+public class MessageProcessor implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(MessageProcessor.class);
+
+    private RocketMQConsumer consumer;
+
+    private HBaseClient hbaseClient;
+
+    private long pullInterval;
+
+    private boolean on = false;
+
+    /**
+     * Constructor.
+     *
+     * @param config the configuration
+     */
+    public MessageProcessor(Config config) {
+        pullInterval = config.getPullInterval();
+        consumer = new RocketMQConsumer(config);
+        hbaseClient = new HBaseClient(config);
+    }
+
+    /**
+     * Starts the message processor by starting out the rocketmq consumer and the hbase client.
+     *
+     * @throws MQClientException
+     * @throws IOException
+     */
+    public void start() throws MQClientException, IOException {
+        consumer.start();
+        hbaseClient.start();
+        on = true;
+        final Thread thread = new Thread(this);
+        thread.start();
+        logger.info("Message processor started.");
+    }
+
+    /**
+     * This is the main method that runs in a separate thread and does the actual processing of pulling message from
+     * rocketmq and writing them into hbase.
+     */
+    @Override
+    public void run() {
+        Map<String, List<MessageExt>> messagesPerTopic;
+        while (on) {
+
+            try {
+                while ((messagesPerTopic = consumer.pull()) == null) {
+                    Thread.sleep(pullInterval);
+                }
+
+                for (Map.Entry<String, List<MessageExt>> entry : messagesPerTopic.entrySet()) {
+                    final String topic = entry.getKey();
+                    final List<MessageExt> messages = entry.getValue();
+                    hbaseClient.put(topic, messages);
+                }
+
+            } catch (Exception e) {
+                logger.error("Error while processing messages.", e);
+            }
+        }
+        consumer.stop();
+        try {
+            hbaseClient.stop();
+        } catch (IOException e) {
+            logger.error("HBase client failed to stop.", e);
+        }
+        logger.info("Message processor stopped.");
+    }
+
+    /**
+     * Stops the message processor.
+     */
+    public void stop() {
+        on = false;
+    }
+}

--- a/rocketmq-hbase/rocketmq-hbase-source/src/main/java/org/apache/rocketmq/hbase/source/RocketMQConsumer.java
+++ b/rocketmq-hbase/rocketmq-hbase-source/src/main/java/org/apache/rocketmq/hbase/source/RocketMQConsumer.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.hbase.source;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.PullStatus;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class represents the RocketMQ consumer that effectively pulls the messages from the RocketMQ topics.
+ */
+public class RocketMQConsumer {
+
+    private static final Logger logger = LoggerFactory.getLogger(RocketMQConsumer.class);
+
+    private DefaultMQPullConsumer consumer;
+
+    private String namesrvAddr;
+
+    private String consumerGroup;
+
+    private MessageModel messageModel;
+
+    private Set<String> topics;
+
+    private int batchSize;
+
+    /**
+     * Constructor.
+     *
+     * @param config the configuration
+     */
+    public RocketMQConsumer(Config config) {
+        this.namesrvAddr = config.getNameserver();
+        this.consumerGroup = config.getConsumerGroup();
+        this.messageModel = MessageModel.valueOf(config.getMessageModel());
+        this.topics = config.getTopics();
+        this.batchSize = config.getBatchSize();
+    }
+
+    /**
+     * Starts the rocketmq consumer.
+     *
+     * @throws MQClientException
+     */
+    public void start() throws MQClientException {
+        consumer = new DefaultMQPullConsumer(consumerGroup);
+        consumer.setNamesrvAddr(namesrvAddr);
+        consumer.setMessageModel(messageModel);
+        consumer.setRegisterTopics(topics);
+        consumer.start();
+        logger.info("RocketMQ consumer started.");
+    }
+
+    /**
+     * Pulls messages from specified topics.
+     *
+     * @return a map containing a list of messages per topic
+     * @throws MQClientException
+     * @throws RemotingException
+     * @throws InterruptedException
+     * @throws MQBrokerException
+     */
+    public Map<String, List<MessageExt>> pull() throws MQClientException, RemotingException, InterruptedException,
+        MQBrokerException {
+
+        final Map<String, List<MessageExt>> messagesPerTopic = new HashMap<>();
+        for (String topic : topics) {
+            final Set<MessageQueue> msgQueues = consumer.fetchSubscribeMessageQueues(topic);
+            for (MessageQueue msgQueue : msgQueues) {
+                final long offset = getMessageQueueOffset(msgQueue);
+                final PullResult pullResult = consumer.pull(msgQueue, null, offset, batchSize);
+
+                if (pullResult.getPullStatus() == PullStatus.FOUND) {
+                    messagesPerTopic.put(topic, pullResult.getMsgFoundList());
+
+                    logger.debug("Pulled {} messages", pullResult.getMsgFoundList().size());
+                }
+            }
+        }
+        return messagesPerTopic.size() > 0 ? messagesPerTopic : null;
+    }
+
+    private long getMessageQueueOffset(MessageQueue queue) throws MQClientException {
+        long offset = consumer.fetchConsumeOffset(queue, false);
+        if (offset < 0) {
+            offset = 0;
+        }
+
+        return offset;
+    }
+
+    /**
+     * Stops the rocketmq consumer.
+     */
+    public void stop() {
+        consumer.shutdown();
+        logger.info("RocketMQ consumer stopped.");
+    }
+}

--- a/rocketmq-hbase/rocketmq-hbase-source/src/main/java/org/apache/rocketmq/hbase/source/RocketMQSource.java
+++ b/rocketmq-hbase/rocketmq-hbase-source/src/main/java/org/apache/rocketmq/hbase/source/RocketMQSource.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.hbase.source;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is the entry point for the RocketMQ source, which replicates RocketMQ topics to HBase tables. It assumes
+ * that (i) each configured RocketMQ topic is maped to a HBase table with the same name; and (ii) the corresponding
+ * HBase tables already exist.
+ */
+public class RocketMQSource {
+
+    private Logger logger = LoggerFactory.getLogger(RocketMQSource.class);
+
+    private Config config;
+
+    public static void main(String[] args) {
+        final RocketMQSource rocketMQSource = new RocketMQSource();
+        rocketMQSource.execute();
+    }
+
+    /**
+     * Executes this source indefinitely.
+     */
+    public void execute() {
+        try {
+            config = new Config();
+            config.load();
+
+            final MessageProcessor processor = new MessageProcessor(config);
+            processor.start();
+
+        } catch (Exception e) {
+            logger.error("Error on starting RocketMQSource.", e);
+        }
+    }
+}

--- a/rocketmq-hbase/rocketmq-hbase-source/src/main/resources/logback.xml
+++ b/rocketmq-hbase/rocketmq-hbase-source/src/main/resources/logback.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<configuration>
+
+
+    <appender name="DefaultConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyy-MM-dd HH:mm:ss,GMT+8} %p - %m%n</pattern>
+            <charset class="java.nio.charset.Charset">UTF-8</charset>
+        </encoder>
+    </appender>
+
+
+    <appender name="DefaultFileAppender"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./logs/rocketmq_hbase.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>./logs/rocketmq_hbase.%i.log
+            </fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>10</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy
+            class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>100MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder>
+            <pattern>%d{yyy-MM-dd HH:mm:ss,GMT+8} %p - %m%n</pattern>
+            <charset class="java.nio.charset.Charset">UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="PositionAppender"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./logs/position.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>./logs/position.%i.log
+            </fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>10</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy
+            class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>10MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder>
+            <pattern>%d{yyy-MM-dd HH:mm:ss,GMT+8} - %m%n</pattern>
+            <charset class="java.nio.charset.Charset">UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <root>
+        <level value="INFO"/>
+        <appender-ref ref="DefaultConsoleAppender"/>
+        <appender-ref ref="DefaultFileAppender"/>
+    </root>
+
+    <logger name="PositionLogger" additivity="false">
+        <level value="INFO"/>
+        <appender-ref ref="PositionAppender"/>
+    </logger>
+
+</configuration>

--- a/rocketmq-hbase/rocketmq-hbase-source/src/main/resources/rocketmq_hbase.conf
+++ b/rocketmq-hbase/rocketmq-hbase-source/src/main/resources/rocketmq_hbase.conf
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+topics=

--- a/rocketmq-hbase/rocketmq-hbase-source/src/test/java/org/apache/rocketmq/hbase/source/RocketMQSourceTest.java
+++ b/rocketmq-hbase/rocketmq-hbase-source/src/test/java/org/apache/rocketmq/hbase/source/RocketMQSourceTest.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.hbase.source;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.rocketmq.broker.BrokerController;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.common.BrokerConfig;
+import org.apache.rocketmq.common.MQVersion;
+import org.apache.rocketmq.common.MixAll;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.namesrv.NamesrvConfig;
+import org.apache.rocketmq.namesrv.NamesrvController;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+import org.apache.rocketmq.remoting.netty.NettyClientConfig;
+import org.apache.rocketmq.remoting.netty.NettyServerConfig;
+import org.apache.rocketmq.remoting.protocol.RemotingCommand;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hbase.util.Bytes.toBytes;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This class tests the RocketMQ source by writing data from RocketMQ to HBase and reading it back.
+ */
+public class RocketMQSourceTest {
+
+    private static final String NAMESERVER = "localhost:9876";
+
+    private static final String PRODUCER_GROUP_NAME = "HBASE_PRODUCER_GROUP_TEST";
+
+    private static final String ROCKETMQ_TOPIC = "rocketmq-hbase-topic-test";
+
+    private static final TableName TABLE_NAME = TableName.valueOf(ROCKETMQ_TOPIC);
+
+    private static final Logger logger = LoggerFactory.getLogger(RocketMQSourceTest.class);
+
+    private static NamesrvController namesrvController;
+
+    private static BrokerController brokerController;
+
+    private HBaseTestingUtility utility;
+
+    private Configuration hbaseConf;
+
+    @Before
+    public void setUp() throws Exception {
+        // start hbase server
+        final Configuration config = HBaseConfiguration.create();
+        utility = new HBaseTestingUtility(config);
+        utility.startMiniCluster();
+        hbaseConf = utility.getConfiguration();
+
+        // create HBase table
+        createTable();
+
+        // start rocketmq server
+        startMQ();
+    }
+
+    @Test
+    public void testRocketMQSource() throws Exception {
+        // write data to rocketmq
+        final String inMsg = "test-rocketmq-hbase-" + System.currentTimeMillis();
+        final String msgId;
+        try {
+            msgId = writeData(inMsg);
+            logger.info("Message written to rocketmq (msgID: " + msgId + ").");
+        } catch (Exception e) {
+            logger.error("Error while writing data.", e);
+            throw new Exception("Error while writing data.", e);
+        }
+
+        // write data from rocketmq to hbase
+        final Config config = new Config();
+        config.setNameserver(NAMESERVER);
+        config.setTopics(ROCKETMQ_TOPIC);
+        config.setZookeeperPort(utility.getZkCluster().getClientPort());
+        config.setPullInterval(0);
+
+        final MessageProcessor messageProcessor = new MessageProcessor(config);
+        try {
+            messageProcessor.start();
+        } catch (Exception e) {
+            logger.error("Error while starting message processor.", e);
+            throw new Exception("Error while starting message processor.", e);
+        }
+        Thread.sleep(1000);
+        messageProcessor.stop();
+        logger.info("Message processor completed successfully.");
+
+        // read data from hbase
+        final String readMsg;
+        try {
+            readMsg = readData(msgId);
+            logger.info("Message read from HBase (msg: " + readMsg + ").");
+        } catch (Exception e) {
+            logger.error("Error while reading data.", e);
+            throw new Exception("Error while reading data.", e);
+        }
+
+        assertEquals(inMsg, readMsg);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (utility != null) {
+            utility.shutdownMiniCluster();
+        }
+
+        if (brokerController != null) {
+            brokerController.shutdown();
+        }
+
+        if (namesrvController != null) {
+            namesrvController.shutdown();
+        }
+    }
+
+    /**
+     * Creates the HBase table.
+     *
+     * @throws IOException
+     */
+    private void createTable() throws IOException {
+        try (HBaseAdmin hBaseAdmin = utility.getHBaseAdmin()) {
+            final HTableDescriptor hTableDescriptor = new HTableDescriptor(TABLE_NAME);
+            final HColumnDescriptor hColumnDescriptor = new HColumnDescriptor(HBaseClient.COLUMN_FAMILY);
+            hTableDescriptor.addFamily(hColumnDescriptor);
+            hBaseAdmin.createTable(hTableDescriptor);
+        }
+        utility.waitUntilAllRegionsAssigned(TABLE_NAME);
+    }
+
+    /**
+     * @param inMsg
+     * @return
+     * @throws MQClientException
+     * @throws UnsupportedEncodingException
+     * @throws RemotingException
+     * @throws InterruptedException
+     * @throws MQBrokerException
+     */
+    private String writeData(String inMsg) throws MQClientException, UnsupportedEncodingException, RemotingException,
+        InterruptedException, MQBrokerException {
+
+        final DefaultMQProducer producer = new DefaultMQProducer(PRODUCER_GROUP_NAME);
+        producer.setNamesrvAddr(NAMESERVER);
+
+        try {
+            producer.start();
+
+            final Message msg = new Message(ROCKETMQ_TOPIC, null, inMsg.getBytes("UTF-8"));
+            final SendResult sendResult = producer.send(msg);
+            logger.info("publish message : {}, sendResult:{}", msg, sendResult);
+            return sendResult.getMsgId();
+        } finally {
+            producer.shutdown();
+        }
+    }
+
+    /**
+     * @param row
+     * @return
+     * @throws IOException
+     */
+    private String readData(String row) throws IOException {
+        try (Table hTable = ConnectionFactory.createConnection(hbaseConf).getTable(TABLE_NAME)) {
+            final Get get = new Get(toBytes(row));
+            get.addFamily(HBaseClient.COLUMN_FAMILY);
+            final Result result = hTable.get(get);
+            final String resultStr = Bytes.toString(result.getValue(HBaseClient.COLUMN_FAMILY, null));
+            return resultStr;
+        }
+    }
+
+    /**
+     * This method starts the RocketMQ server.
+     *
+     * @throws Exception
+     */
+    private static void startMQ() throws Exception {
+        startNamesrv();
+        startBroker();
+
+        Thread.sleep(2000);
+    }
+
+    /**
+     * This method starts the RocketMQ nameserver.
+     *
+     * @throws Exception
+     */
+    private static void startNamesrv() throws Exception {
+
+        NamesrvConfig namesrvConfig = new NamesrvConfig();
+        NettyServerConfig nettyServerConfig = new NettyServerConfig();
+        nettyServerConfig.setListenPort(9876);
+
+        namesrvController = new NamesrvController(namesrvConfig, nettyServerConfig);
+        boolean initResult = namesrvController.initialize();
+        if (!initResult) {
+            namesrvController.shutdown();
+            throw new Exception("Name server controller failed to initialize.");
+        }
+        namesrvController.start();
+    }
+
+    /**
+     * This method starts the RocketMQ broker.
+     *
+     * @throws Exception
+     */
+    private static void startBroker() throws Exception {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, Integer.toString(MQVersion.CURRENT_VERSION));
+
+        BrokerConfig brokerConfig = new BrokerConfig();
+        brokerConfig.setNamesrvAddr(NAMESERVER);
+        brokerConfig.setBrokerId(MixAll.MASTER_ID);
+        NettyServerConfig nettyServerConfig = new NettyServerConfig();
+        nettyServerConfig.setListenPort(10911);
+        NettyClientConfig nettyClientConfig = new NettyClientConfig();
+        MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+
+        brokerController = new BrokerController(brokerConfig, nettyServerConfig, nettyClientConfig, messageStoreConfig);
+        boolean initResult = brokerController.initialize();
+        if (!initResult) {
+            brokerController.shutdown();
+            throw new Exception();
+        }
+        brokerController.start();
+    }
+
+}

--- a/rocketmq-hbase/style/copyright/Apache.xml
+++ b/rocketmq-hbase/style/copyright/Apache.xml
@@ -1,0 +1,23 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<component name="CopyrightManager">
+    <copyright>
+        <option name="myName" value="Apache" />
+        <option name="notice" value="Licensed to the Apache Software Foundation (ASF) under one or more&#10;contributor license agreements.  See the NOTICE file distributed with&#10;this work for additional information regarding copyright ownership.&#10;The ASF licenses this file to You under the Apache License, Version 2.0&#10;(the &quot;License&quot;); you may not use this file except in compliance with&#10;the License.  You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    </copyright>
+</component>

--- a/rocketmq-hbase/style/copyright/profiles_settings.xml
+++ b/rocketmq-hbase/style/copyright/profiles_settings.xml
@@ -1,0 +1,64 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<component name="CopyrightManager">
+    <settings default="Apache">
+        <module2copyright>
+            <element module="All" copyright="Apache"/>
+        </module2copyright>
+        <LanguageOptions name="GSP">
+            <option name="fileTypeOverride" value="3"/>
+            <option name="prefixLines" value="false"/>
+        </LanguageOptions>
+        <LanguageOptions name="HTML">
+            <option name="fileTypeOverride" value="3"/>
+            <option name="prefixLines" value="false"/>
+        </LanguageOptions>
+        <LanguageOptions name="JAVA">
+            <option name="fileTypeOverride" value="3" />
+            <option name="addBlankAfter" value="false" />
+        </LanguageOptions>
+        <LanguageOptions name="JSP">
+            <option name="fileTypeOverride" value="3"/>
+            <option name="prefixLines" value="false"/>
+        </LanguageOptions>
+        <LanguageOptions name="JSPX">
+            <option name="fileTypeOverride" value="3"/>
+            <option name="prefixLines" value="false"/>
+        </LanguageOptions>
+        <LanguageOptions name="MXML">
+            <option name="fileTypeOverride" value="3"/>
+            <option name="prefixLines" value="false"/>
+        </LanguageOptions>
+        <LanguageOptions name="Properties">
+            <option name="fileTypeOverride" value="3"/>
+            <option name="block" value="false"/>
+        </LanguageOptions>
+        <LanguageOptions name="SPI">
+            <option name="fileTypeOverride" value="3"/>
+            <option name="block" value="false"/>
+        </LanguageOptions>
+        <LanguageOptions name="XML">
+            <option name="fileTypeOverride" value="3"/>
+            <option name="prefixLines" value="false"/>
+        </LanguageOptions>
+        <LanguageOptions name="__TEMPLATE__">
+            <option name="separateBefore" value="true"/>
+            <option name="lenBefore" value="1"/>
+        </LanguageOptions>
+    </settings>
+</component>

--- a/rocketmq-hbase/style/rmq_checkstyle.xml
+++ b/rocketmq-hbase/style/rmq_checkstyle.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<!--Refer http://checkstyle.sourceforge.net/reports/google-java-style.html#s2.2-file-encoding -->
+<module name="Checker">
+
+    <property name="localeLanguage" value="en"/>
+
+    <!--To configure the check to report on the first instance in each file-->
+    <module name="FileTabCharacter"/>
+
+    <!-- header -->
+    <module name="RegexpHeader">
+        <property name="header" value="/\*\nLicensed to the Apache Software Foundation*"/>
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="System\.out\.println"/>
+        <property name="message" value="Prohibit invoking System.out.println in source code !"/>
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="//FIXME"/>
+        <property name="message" value="Recommended fix FIXME task !"/>
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="//TODO"/>
+        <property name="message" value="Recommended fix TODO task !"/>
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="@alibaba"/>
+        <property name="message" value="Recommended remove @alibaba keyword!"/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="@taobao"/>
+        <property name="message" value="Recommended remove @taobao keyword!"/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="@author"/>
+        <property name="message" value="Recommended remove @author tag in javadoc!"/>
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format"
+                  value=".*[\u3400-\u4DB5\u4E00-\u9FA5\u9FA6-\u9FBB\uF900-\uFA2D\uFA30-\uFA6A\uFA70-\uFAD9\uFF00-\uFFEF\u2E80-\u2EFF\u3000-\u303F\u31C0-\u31EF]+.*"/>
+        <property name="message" value="Not allow chinese character !"/>
+    </module>
+
+    <module name="FileLength">
+        <property name="max" value="3000"/>
+    </module>
+
+    <module name="TreeWalker">
+
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true"/>
+        </module>
+        <module name="RedundantImport"/>
+
+        <!--<module name="IllegalImport" />-->
+
+        <!--Checks that classes that override equals() also override hashCode()-->
+        <module name="EqualsHashCode"/>
+        <!--Checks for over-complicated boolean expressions. Currently finds code like if (topic == true), topic || true, !false, etc.-->
+        <module name="SimplifyBooleanExpression"/>
+        <module name="OneStatementPerLine"/>
+        <module name="UnnecessaryParentheses"/>
+        <!--Checks for over-complicated boolean return statements. For example the following code-->
+        <module name="SimplifyBooleanReturn"/>
+
+        <!--Check that the default is after all the cases in producerGroup switch statement-->
+        <module name="DefaultComesLast"/>
+        <!--Detects empty statements (standalone ";" semicolon)-->
+        <module name="EmptyStatement"/>
+        <!--Checks that long constants are defined with an upper ell-->
+        <module name="UpperEll"/>
+        <module name="ConstantName">
+            <property name="format" value="(^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$)|(^log$)"/>
+        </module>
+        <!--Checks that local, non-final variable names conform to producerGroup format specified by the format property-->
+        <module name="LocalVariableName"/>
+        <!--Validates identifiers for local, final variables, including catch parameters-->
+        <module name="LocalFinalVariableName"/>
+        <!--Validates identifiers for non-static fields-->
+        <module name="MemberName"/>
+        <!--Validates identifiers for class type parameters-->
+        <module name="ClassTypeParameterName">
+            <property name="format" value="^[A-Z0-9]*$"/>
+        </module>
+        <!--Validates identifiers for method type parameters-->
+        <module name="MethodTypeParameterName">
+            <property name="format" value="^[A-Z0-9]*$"/>
+        </module>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+        <!--Checks that there are no import statements that use the * notation-->
+        <module name="AvoidStarImport"/>
+
+        <!--whitespace-->
+        <module name="GenericWhitespace"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+        </module>
+        <module name="Indentation"/>
+        <module name="MethodParamPad"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+    </module>
+</module>

--- a/rocketmq-hbase/style/rmq_codeStyle.xml
+++ b/rocketmq-hbase/style/rmq_codeStyle.xml
@@ -1,0 +1,143 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<code_scheme name="rocketmq">
+    <option name="USE_SAME_INDENTS" value="true"/>
+    <option name="IGNORE_SAME_INDENTS_FOR_LANGUAGES" value="true"/>
+    <option name="OTHER_INDENT_OPTIONS">
+        <value>
+            <option name="INDENT_SIZE" value="4"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="4"/>
+            <option name="USE_TAB_CHARACTER" value="false"/>
+            <option name="SMART_TABS" value="false"/>
+            <option name="LABEL_INDENT_SIZE" value="0"/>
+            <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+            <option name="USE_RELATIVE_INDENTS" value="false"/>
+        </value>
+    </option>
+    <option name="PREFER_LONGER_NAMES" value="false"/>
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000"/>
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000"/>
+    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value/>
+    </option>
+    <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+            <package name="" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="" withSubpackages="true" static="true"/>
+        </value>
+    </option>
+    <option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
+    <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
+    <option name="JD_P_AT_EMPTY_LINES" value="false"/>
+    <option name="JD_KEEP_INVALID_TAGS" value="false"/>
+    <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true"/>
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+    <option name="WHILE_ON_NEW_LINE" value="true"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="SPACE_AFTER_TYPE_CAST" value="true"/>
+    <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true"/>
+    <option name="LABELED_STATEMENT_WRAP" value="1"/>
+    <option name="WRAP_COMMENTS" value="true"/>
+    <option name="METHOD_ANNOTATION_WRAP" value="1"/>
+    <option name="CLASS_ANNOTATION_WRAP" value="1"/>
+    <option name="FIELD_ANNOTATION_WRAP" value="1"/>
+    <JavaCodeStyleSettings>
+        <option name="CLASS_NAMES_IN_JAVADOC" value="3"/>
+    </JavaCodeStyleSettings>
+    <XML>
+        <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
+    </XML>
+    <ADDITIONAL_INDENT_OPTIONS fileType="haml">
+        <option name="INDENT_SIZE" value="2"/>
+    </ADDITIONAL_INDENT_OPTIONS>
+    <codeStyleSettings language="Groovy">
+        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+        <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+        <option name="ALIGN_MULTILINE_FOR" value="false"/>
+        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+        <option name="METHOD_ANNOTATION_WRAP" value="1"/>
+        <option name="CLASS_ANNOTATION_WRAP" value="1"/>
+        <option name="FIELD_ANNOTATION_WRAP" value="1"/>
+        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+        <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="HOCON">
+        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+        <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+        <option name="WHILE_ON_NEW_LINE" value="true"/>
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+        <option name="ALIGN_MULTILINE_FOR" value="false"/>
+        <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true"/>
+        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+        <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true"/>
+        <option name="LABELED_STATEMENT_WRAP" value="1"/>
+        <option name="METHOD_ANNOTATION_WRAP" value="1"/>
+        <option name="CLASS_ANNOTATION_WRAP" value="1"/>
+        <option name="FIELD_ANNOTATION_WRAP" value="1"/>
+        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+        <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JSON">
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+    </codeStyleSettings>
+    <codeStyleSettings language="Scala">
+        <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+        <option name="WHILE_ON_NEW_LINE" value="true"/>
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+        <option name="ALIGN_MULTILINE_FOR" value="false"/>
+        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+        <option name="METHOD_ANNOTATION_WRAP" value="1"/>
+        <option name="CLASS_ANNOTATION_WRAP" value="1"/>
+        <option name="FIELD_ANNOTATION_WRAP" value="1"/>
+        <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+        <indentOptions>
+            <option name="INDENT_SIZE" value="4"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="4"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+        <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+        </indentOptions>
+    </codeStyleSettings>
+</code_scheme>


### PR DESCRIPTION
_The work covered by this PR was carried out as part of the GSoC 2018._

This PR provides plugins that integrate RocketMQ with the HBase database. Namely, it includes (i) the HBase sink, that replicates HBase tables to RocketMQ topics; and (ii) the HBase source, which replicates RocketMQ topics to HBase tables.

The HBase sink functions as a replication endpoint for HBase. This endpoint can track updates (put and delete operations) performed on specified tables, and replicate them to a RocketMQ topic using reliable synchronous transmission.

The HBase source consists of a daemon program that is continuously pulling messages, at regular time intervals, from specified RocketMQ topics and writing them to HBase tables using a broadcast message model.

Code is documented and unit tests are provided.