### PR TITLE
[ISSUE 101] New Feature: support sending transactional message with rocketmq-spring-boot-starter

### DIFF
--- a/rocketmq-spring-boot-starter/README.md
+++ b/rocketmq-spring-boot-starter/README.md
@@ -85,31 +85,34 @@ public class ProducerApplication implements CommandLineRunner{
 
     public void run(String... args) throws Exception {
         try {
-                    // create txProducer
-                    rocketMQTemplate.createAndStartTransactionMQProducer("test",
-                        new TransactionListener() {
-                        @Override
-                        public LocalTransactionState executeLocalTransaction(Message msg, Object arg) {
-                            // ... local transaction process
-                            return LocalTransactionState.UNKNOW;
-                        }
-
-                        @Override
-                        public LocalTransactionState checkLocalTransaction(MessageExt msg) {
-                            // ... check transaction status and retun bollback or commit
-                            return LocalTransactionState.COMMIT_MESSAGE;
-                        }
-                    }, null);
-
-                    // send transactional message with the txProducer
-                    org.apache.rocketmq.common.message.Message msg = ...
-                    rocketMQTemplate.sendMessageInTransaction("test", msg, null);
+            // send transactional message with the txProducer
+            org.apache.rocketmq.common.message.Message msg = ...
+            // in sendMessageInTransaction(), the first parameter transaction name ("test")
+            // must be same with the @RocketMQTransactionListener's member field 'transName'
+            rocketMQTemplate.sendMessageInTransaction("test", msg, null);
         } catch (MQClientException e) {
-                    e.printStackTrace();
-                    fail("failed to create txProducer and send transactional msg!");
+            e.printStackTrace(System.out);
+            fail("failed to create txProducer and send transactional msg!");
         }
     }
+
+    // define transaction listener with the annotation @RocketMQTransactionListener
+    @RocketMQTransactionListener(transName="test")
+    class TransactionListenerImpl implements TransactionListener() {
+          @Override
+          public LocalTransactionState executeLocalTransaction(Message msg, Object arg) {
+            // ... local transaction process
+            return LocalTransactionState.UNKNOW;
+          }
+
+          @Override
+          public LocalTransactionState checkLocalTransaction(MessageExt msg) {
+            // ... check transaction status and retun bollback or commit
+            return LocalTransactionState.COMMIT_MESSAGE;
+          }
+    }
 }
+
 ```
 
 > More relevant configurations for produce:

--- a/rocketmq-spring-boot-starter/README_zh_CN.md
+++ b/rocketmq-spring-boot-starter/README_zh_CN.md
@@ -85,29 +85,31 @@ public class ProducerApplication implements CommandLineRunner{
 
     public void run(String... args) throws Exception {
         try {
-                    // create txProducer
-                    rocketMQTemplate.createAndStartTransactionMQProducer("test",
-                        new TransactionListener() {
-                        @Override
-                        public LocalTransactionState executeLocalTransaction(Message msg, Object arg) {
-                            // ... local transaction process
-                            return LocalTransactionState.UNKNOW;
-                        }
-
-                        @Override
-                        public LocalTransactionState checkLocalTransaction(MessageExt msg) {
-                            // ... check transaction status and retun bollback or commit
-                            return LocalTransactionState.COMMIT_MESSAGE;
-                        }
-                    }, null);
-
-                    // send transactional message with the txProducer
-                    org.apache.rocketmq.common.message.Message msg = ...
-                    rocketMQTemplate.sendMessageInTransaction("test", msg, null);
+            // send transactional message with the txProducer
+            org.apache.rocketmq.common.message.Message msg = ...
+            // in sendMessageInTransaction(), the first parameter transaction name ("test")
+            // must be same with the @RocketMQTransactionListener's member field 'transName'
+            rocketMQTemplate.sendMessageInTransaction("test", msg, null);
         } catch (MQClientException e) {
-                    e.printStackTrace();
-                    fail("failed to create txProducer and send transactional msg!");
+            e.printStackTrace(System.out);
+            fail("failed to create txProducer and send transactional msg!");
         }
+    }
+
+    // define transaction listener with the annotation @RocketMQTransactionListener
+    @RocketMQTransactionListener(transName="test")
+    class TransactionListenerImpl implements TransactionListener() {
+          @Override
+          public LocalTransactionState executeLocalTransaction(Message msg, Object arg) {
+            // ... local transaction process
+            return LocalTransactionState.UNKNOW;
+          }
+
+          @Override
+          public LocalTransactionState checkLocalTransaction(MessageExt msg) {
+            // ... check transaction status and retun bollback or commit
+            return LocalTransactionState.COMMIT_MESSAGE;
+          }
     }
 }
 ```

--- a/rocketmq-spring-boot-starter/README_zh_CN.md
+++ b/rocketmq-spring-boot-starter/README_zh_CN.md
@@ -16,7 +16,7 @@
 - [x] 顺序消费
 - [x] 并发消费（广播/集群）
 - [x] One-way方式发送
-- [ ] 事务方式发送
+- [x] 事务方式发送
 - [ ] Pull消费 
 
 ## Quick Start
@@ -68,6 +68,46 @@ public class ProducerApplication implements CommandLineRunner{
         private String orderId;
         
         private BigDecimal paidMoney;
+    }
+}
+```
+
+发送事物性消息
+```java
+@SpringBootApplication
+public class ProducerApplication implements CommandLineRunner{
+    @Resource
+    private RocketMQTemplate rocketMQTemplate;
+
+    public static void main(String[] args){
+        SpringApplication.run(ProducerApplication.class, args);
+    }
+
+    public void run(String... args) throws Exception {
+        try {
+                    // create txProducer
+                    rocketMQTemplate.createAndStartTransactionMQProducer("test",
+                        new TransactionListener() {
+                        @Override
+                        public LocalTransactionState executeLocalTransaction(Message msg, Object arg) {
+                            // ... local transaction process
+                            return LocalTransactionState.UNKNOW;
+                        }
+
+                        @Override
+                        public LocalTransactionState checkLocalTransaction(MessageExt msg) {
+                            // ... check transaction status and retun bollback or commit
+                            return LocalTransactionState.COMMIT_MESSAGE;
+                        }
+                    }, null);
+
+                    // send transactional message with the txProducer
+                    org.apache.rocketmq.common.message.Message msg = ...
+                    rocketMQTemplate.sendMessageInTransaction("test", msg, null);
+        } catch (MQClientException e) {
+                    e.printStackTrace();
+                    fail("failed to create txProducer and send transactional msg!");
+        }
     }
 }
 ```

--- a/rocketmq-spring-boot-starter/pom.xml
+++ b/rocketmq-spring-boot-starter/pom.xml
@@ -44,7 +44,7 @@
 
     <properties>
         <spring.boot.version>1.5.9.RELEASE</spring.boot.version>
-        <rocketmq-version>4.2.0</rocketmq-version>
+        <rocketmq-version>4.4.0-SNAPSHOT</rocketmq-version>
         <java.version>1.8</java.version>
 
         <resource.delimiter>@</resource.delimiter> <!-- delimiter that doesn't clash with Spring ${} placeholders -->

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.spring.starter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.spring.starter.annotation.RocketMQMessageListener;
+import org.apache.rocketmq.spring.starter.config.TransactionHandlerRegistry;
 import org.apache.rocketmq.spring.starter.core.DefaultRocketMQListenerContainer;
 import org.apache.rocketmq.spring.starter.core.RocketMQListener;
 import org.apache.rocketmq.spring.starter.core.RocketMQTemplate;
@@ -35,6 +36,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -47,6 +49,7 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.util.Assert;
@@ -59,6 +62,12 @@ import static org.apache.rocketmq.spring.starter.core.DefaultRocketMQListenerCon
 @Order
 @Slf4j
 public class RocketMQAutoConfiguration {
+    @Bean
+    @ConditionalOnClass(DefaultMQProducer.class)
+    @ConditionalOnMissingBean(DefaultMQProducer.class)
+    public TransactionHandlerRegistry transactionHandlerRegistry() {
+        return new TransactionHandlerRegistry();
+    }
 
     @Bean
     @ConditionalOnClass(DefaultMQProducer.class)
@@ -188,5 +197,12 @@ public class RocketMQAutoConfiguration {
 
             log.info("register rocketMQ listener to container, listenerBeanName:{}, containerBeanName:{}", beanName, containerBeanName);
         }
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Bean(name = RocketMQConfigUtils.ROCKET_MQ_TRANSACTION_ANNOTATION_PROCESSOR_BEAN_NAME)
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    public RocketMQTransactionAnnotationProcessor RocketMQTransactionAnnotationProcessor() {
+        return new RocketMQTransactionAnnotationProcessor();
     }
 }

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.rocketmq.spring.starter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.rocketmq.spring.starter.annotation.RocketMQMessageListener;
+import org.apache.rocketmq.spring.starter.annotation.RocketMQTransactionListener;
 import org.apache.rocketmq.spring.starter.config.TransactionHandlerRegistry;
 import org.apache.rocketmq.spring.starter.core.DefaultRocketMQListenerContainer;
 import org.apache.rocketmq.spring.starter.core.RocketMQListener;

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQConfigUtils.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQConfigUtils.java
@@ -1,0 +1,30 @@
+package org.apache.rocketmq.spring.starter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+public class RocketMQConfigUtils {
+  /**
+   * The bean name of the internally managed RocketMQ transaction annotation processor.
+   */
+  public static final String ROCKET_MQ_TRANSACTION_ANNOTATION_PROCESSOR_BEAN_NAME =
+      "org.springframework.rocketmq.spring.starter.internalRocketMQTransAnnotationProcessor";
+
+  public static final String ROCKET_MQ_TRANSACTION_DEFAULT_GLOBAL_NAME =
+      "rocket_mq_transaction_defaut_global_name";
+}

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQConfigUtils.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQConfigUtils.java
@@ -27,4 +27,6 @@ public class RocketMQConfigUtils {
 
   public static final String ROCKET_MQ_TRANSACTION_DEFAULT_GLOBAL_NAME =
       "rocket_mq_transaction_defaut_global_name";
+
+  public static final int ROCKET_MQ_TRANSACTION_MAX_PRODUCER_NUM = 3000;
 }

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQTransactionAnnotationProcessor.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQTransactionAnnotationProcessor.java
@@ -11,7 +11,6 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.*;
-import org.springframework.context.expression.StandardBeanExpressionResolver;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationUtils;
 
@@ -22,7 +21,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public class RocketMQTransactionAnnotationProcessor
     implements BeanPostProcessor, Ordered, BeanFactoryAware, SmartInitializingSingleton {
   private BeanFactory beanFactory;
-  private BeanExpressionResolver resolver = new StandardBeanExpressionResolver();
   private final Set<Class<?>> nonAnnotatedClasses =
       Collections.newSetFromMap(new ConcurrentHashMap<Class<?>, Boolean>(64));
 
@@ -33,9 +31,6 @@ public class RocketMQTransactionAnnotationProcessor
   @Override
   public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
     this.beanFactory = beanFactory;
-    if (beanFactory instanceof ConfigurableListableBeanFactory) {
-      this.resolver = ((ConfigurableListableBeanFactory) beanFactory).getBeanExpressionResolver();
-    }
   }
 
   @Override
@@ -47,10 +42,10 @@ public class RocketMQTransactionAnnotationProcessor
   public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
     if (!this.nonAnnotatedClasses.contains(bean.getClass())) {
       Class<?> targetClass = AopUtils.getTargetClass(bean);
-      RocketMQTransactionListener listener = AnnotationUtils.findAnnotation(targetClass, RocketMQTransactionListener.class);;
+      RocketMQTransactionListener listener = AnnotationUtils.findAnnotation(targetClass, RocketMQTransactionListener.class);
       this.nonAnnotatedClasses.add(bean.getClass());
       if (listener == null) { //for quick search
-          log.trace("No @RocketMQTransactionListener annotations found on bean type: {}", bean.getClass());
+          log.trace("no @RocketMQTransactionListener annotations found on bean type: {}", bean.getClass());
       }else {
             try{
               processTransactionListenerAnnotation(listener, bean, beanName);
@@ -66,7 +61,7 @@ public class RocketMQTransactionAnnotationProcessor
 
   private void processTransactionListenerAnnotation(RocketMQTransactionListener anno, Object bean, String beanName) throws MQClientException {
     if (!TransactionListener.class.isAssignableFrom(bean.getClass())) {
-      throw new MQClientException(-1, "Bad usage of @RocketMQTransactionListener, the class must implements interface org.apache.rocketmq.client.producer.TransactionListener");
+      throw new MQClientException(-1, "bad usage of @RocketMQTransactionListener, the class must implements interface org.apache.rocketmq.client.producer.TransactionListener");
     }
     TransactionHandler transactionHandler = new TransactionHandler();
     transactionHandler.setBeanFactory(this.beanFactory);

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQTransactionAnnotationProcessor.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQTransactionAnnotationProcessor.java
@@ -50,8 +50,8 @@ public class RocketMQTransactionAnnotationProcessor
             try{
               processTransactionListenerAnnotation(listener, bean, beanName);
             } catch (MQClientException e) {
-              log.error("failed to process annotation " + listener, e);
-              throw new BeanCreationException("failed to process annotation " + listener, e);
+              log.error("Failed to process annotation " + listener, e);
+              throw new BeanCreationException("Failed to process annotation " + listener, e);
             }
           }
     }
@@ -61,7 +61,7 @@ public class RocketMQTransactionAnnotationProcessor
 
   private void processTransactionListenerAnnotation(RocketMQTransactionListener anno, Object bean, String beanName) throws MQClientException {
     if (!TransactionListener.class.isAssignableFrom(bean.getClass())) {
-      throw new MQClientException(-1, "bad usage of @RocketMQTransactionListener, the class must implements interface org.apache.rocketmq.client.producer.TransactionListener");
+      throw new MQClientException(-1, "Bad usage of @RocketMQTransactionListener, the class must implements interface org.apache.rocketmq.client.producer.TransactionListener");
     }
     TransactionHandler transactionHandler = new TransactionHandler();
     transactionHandler.setBeanFactory(this.beanFactory);

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQTransactionAnnotationProcessor.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/RocketMQTransactionAnnotationProcessor.java
@@ -1,0 +1,91 @@
+package org.apache.rocketmq.spring.starter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.TransactionListener;
+import org.apache.rocketmq.spring.starter.annotation.RocketMQTransactionListener;
+import org.apache.rocketmq.spring.starter.config.TransactionHandler;
+import org.apache.rocketmq.spring.starter.config.TransactionHandlerRegistry;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.*;
+import org.springframework.context.expression.StandardBeanExpressionResolver;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+public class RocketMQTransactionAnnotationProcessor
+    implements BeanPostProcessor, Ordered, BeanFactoryAware, SmartInitializingSingleton {
+  private BeanFactory beanFactory;
+  private BeanExpressionResolver resolver = new StandardBeanExpressionResolver();
+  private final Set<Class<?>> nonAnnotatedClasses =
+      Collections.newSetFromMap(new ConcurrentHashMap<Class<?>, Boolean>(64));
+
+  @Autowired
+  private TransactionHandlerRegistry transactionHandlerRegistry;
+
+
+  @Override
+  public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+    this.beanFactory = beanFactory;
+    if (beanFactory instanceof ConfigurableListableBeanFactory) {
+      this.resolver = ((ConfigurableListableBeanFactory) beanFactory).getBeanExpressionResolver();
+    }
+  }
+
+  @Override
+  public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+    return bean;
+  }
+
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+    if (!this.nonAnnotatedClasses.contains(bean.getClass())) {
+      Class<?> targetClass = AopUtils.getTargetClass(bean);
+      RocketMQTransactionListener listener = AnnotationUtils.findAnnotation(targetClass, RocketMQTransactionListener.class);;
+      this.nonAnnotatedClasses.add(bean.getClass());
+      if (listener == null) { //for quick search
+          log.trace("No @RocketMQTransactionListener annotations found on bean type: {}", bean.getClass());
+      }else {
+            try{
+              processTransactionListenerAnnotation(listener, bean, beanName);
+            } catch (MQClientException e) {
+              log.error("failed to process annotation " + listener, e);
+              throw new BeanCreationException("failed to process annotation " + listener, e);
+            }
+          }
+    }
+
+    return bean;
+  }
+
+  private void processTransactionListenerAnnotation(RocketMQTransactionListener anno, Object bean, String beanName) throws MQClientException {
+    if (!TransactionListener.class.isAssignableFrom(bean.getClass())) {
+      throw new MQClientException(-1, "Bad usage of @RocketMQTransactionListener, the class must implements interface org.apache.rocketmq.client.producer.TransactionListener");
+    }
+    TransactionHandler transactionHandler = new TransactionHandler();
+    transactionHandler.setBeanFactory(this.beanFactory);
+    transactionHandler.setName(anno.transName());
+    transactionHandler.setBeanName(bean.getClass().getName());
+    transactionHandler.setListener((TransactionListener)bean);
+    transactionHandler.setCheckExecutor(anno.corePoolSize(), anno.maximumPoolSize(),
+        anno.keepAliveTime(), anno.blockingQueueSize());
+
+    transactionHandlerRegistry.registerTransactionHandler(transactionHandler);
+  }
+
+  @Override
+  public int getOrder() {
+    return LOWEST_PRECEDENCE;
+  }
+
+  @Override
+  public void afterSingletonsInstantiated() {
+    //do nothing
+  }
+}

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/annotation/RocketMQTransactionListener.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/annotation/RocketMQTransactionListener.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.starter.annotation;
+
+import org.apache.rocketmq.spring.starter.RocketMQConfigUtils;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface RocketMQTransactionListener {
+
+    /**
+     * transaction name
+     */
+    String transName() default RocketMQConfigUtils.ROCKET_MQ_TRANSACTION_DEFAULT_GLOBAL_NAME;
+
+    //set ExecutorService params
+    int corePoolSize() default 1;
+    int maximumPoolSize() default 1;
+    long keepAliveTime() default 1000*60; //60ms
+    int blockingQueueSize() default 2000;
+}

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/config/TransactionHandler.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/config/TransactionHandler.java
@@ -1,0 +1,58 @@
+package org.apache.rocketmq.spring.starter.config;
+
+import org.apache.rocketmq.client.producer.TransactionListener;
+import org.springframework.beans.factory.BeanFactory;
+
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class TransactionHandler {
+  private String name;
+  private String beanName;
+  private TransactionListener bean;
+  private BeanFactory beanFactory;
+  private ThreadPoolExecutor checkExecutor;
+
+  public String getBeanName() {
+    return beanName;
+  }
+
+  public void setBeanName(String beanName) {
+    this.beanName = beanName;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public BeanFactory getBeanFactory() {
+    return beanFactory;
+  }
+
+  public void setBeanFactory(BeanFactory beanFactory) {
+    this.beanFactory = beanFactory;
+  }
+
+  public void setListener(TransactionListener listener) {
+    this.bean = listener;
+  }
+
+  public TransactionListener getListener() {
+    return this.bean;
+  }
+
+  public void setCheckExecutor(int corePoolSize, int maxPoolSize, long keepAliveTime, int blockingQueueSize) {
+    this.checkExecutor = new ThreadPoolExecutor(corePoolSize, maxPoolSize,
+        keepAliveTime, TimeUnit.MILLISECONDS,
+        new LinkedBlockingDeque<>(blockingQueueSize));
+  }
+
+  public ThreadPoolExecutor getCheckExecutor() {
+    return checkExecutor;
+  }
+}

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/config/TransactionHandlerRegistry.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/config/TransactionHandlerRegistry.java
@@ -3,6 +3,7 @@ package org.apache.rocketmq.spring.starter.config;
 import io.netty.util.internal.ConcurrentSet;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.spring.starter.core.RocketMQTemplate;
+import org.apache.rocketmq.spring.starter.core.RocketMQTxInternalUtil;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -35,6 +36,6 @@ public class TransactionHandlerRegistry implements DisposableBean {
               handler.getBeanName()));
     listenerContainers.add(handler.getName());
 
-    rocketMQTemplate.createAndStartTransactionMQProducer(handler.getName(), handler.getListener(), handler.getCheckExecutor());
+    RocketMQTxInternalUtil.create(rocketMQTemplate).createAndStartTransactionMQProducer(handler.getName(), handler.getListener(), handler.getCheckExecutor());
   }
 }

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/config/TransactionHandlerRegistry.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/config/TransactionHandlerRegistry.java
@@ -1,0 +1,40 @@
+package org.apache.rocketmq.spring.starter.config;
+
+import io.netty.util.internal.ConcurrentSet;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.spring.starter.core.RocketMQTemplate;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+public class TransactionHandlerRegistry implements DisposableBean {
+  @Autowired
+  private RocketMQTemplate rocketMQTemplate;
+
+  private final Set<String> listenerContainers = new ConcurrentSet<>();
+
+  public TransactionHandlerRegistry() {
+  }
+
+  public Collection<String> getAllTrans() {
+    return Collections.unmodifiableSet(listenerContainers);
+  }
+
+  @Override
+  public void destroy() throws Exception {
+    listenerContainers.clear();
+  }
+
+  public void registerTransactionHandler(TransactionHandler handler) throws MQClientException {
+    if (listenerContainers.contains(handler.getName()))
+      throw new MQClientException(-1,
+          String.format("The transaction name [%s] has been defined in TransactionListener [%s]", handler.getName(),
+              handler.getBeanName()));
+    listenerContainers.add(handler.getName());
+
+    rocketMQTemplate.createAndStartTransactionMQProducer(handler.getName(), handler.getListener(), handler.getCheckExecutor());
+  }
+}

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
@@ -552,6 +552,7 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
      * @throws MQClientException
      */
     public void removeTransactionMQProducer(String name) throws MQClientException {
+        name = (name==null)? RocketMQConfigUtils.ROCKET_MQ_TRANSACTION_DEFAULT_GLOBAL_NAME:name;
         if (cache.containsKey(name)) {
             DefaultMQProducer cachedProducer = cache.get(name);
             cachedProducer.shutdown();

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
@@ -522,7 +522,7 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
         TransactionMQProducer cachedProducer = cache.get(name);
         if (cachedProducer == null) {
             throw new MQClientException(-1,
-                String.format("can not found MQProducer '%s' in cache! " +
+                String.format("Can not found MQProducer '%s' in cache! " +
                     "please define @RocketMQTransactionListener(transName=\"%s\") class " +
                     "or invoke createOrGetStartedTransactionMQProducer() to create it firstly",
                     name, name));
@@ -601,12 +601,12 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
                                                                     ExecutorService executorService) throws MQClientException {
         name = (name==null)? RocketMQConfigUtils.ROCKET_MQ_TRANSACTION_DEFAULT_GLOBAL_NAME:name;
         if (cache.containsKey(name)) {
-            log.info(String.format("get TransactionMQProducer '%s' from cache", name));
+            log.info(String.format("Get TransactionMQProducer '%s' from cache", name));
             return false;
         }
 
         if (cache.size()>=RocketMQConfigUtils.ROCKET_MQ_TRANSACTION_MAX_PRODUCER_NUM) {
-            throw new MQClientException(-1, "too much transactional producers created!!!");
+            throw new MQClientException(-1, "Too much transactional producers created!!!");
         }
 
         TransactionMQProducer txProducer = createTransactionMQProducer(name, transactionListener, executorService);

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
@@ -32,6 +32,7 @@ import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.producer.*;
 import org.apache.rocketmq.client.producer.selector.SelectMessageQueueByHash;
 import org.apache.rocketmq.common.message.MessageConst;
+import org.apache.rocketmq.spring.starter.RocketMQConfigUtils;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.messaging.Message;
@@ -516,10 +517,12 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
     }
 
     private TransactionMQProducer stageMQProducer(String name) throws MQClientException {
+        name = (name==null)? RocketMQConfigUtils.ROCKET_MQ_TRANSACTION_DEFAULT_GLOBAL_NAME:name;
+
         TransactionMQProducer cachedProducer = cache.get(name);
         if (cachedProducer == null) {
             throw new MQClientException(-1,
-                String.format("Can not found MQProducer '%s' in cache! please invoke createOrGetStartedTransactionMQProducer() to create it firstly", name));
+                String.format("Can not found MQProducer '%s' in cache! please define @RocketMQTransactionListener class or invoke createOrGetStartedTransactionMQProducer() to create it firstly", name));
         }
 
         return cachedProducer;
@@ -563,6 +566,7 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
      */
     public synchronized boolean createAndStartTransactionMQProducer(String name, TransactionListener transactionListener,
                                                                     ExecutorService executorService) throws MQClientException {
+        name = (name==null)? RocketMQConfigUtils.ROCKET_MQ_TRANSACTION_DEFAULT_GLOBAL_NAME:name;
         if (cache.containsKey(name)) {
             log.info(String.format("get TransactionMQProducer '%s' from cache", name));
             return false;

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTemplate.java
@@ -22,13 +22,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.rocketmq.client.producer.DefaultMQProducer;
-import org.apache.rocketmq.client.producer.MessageQueueSelector;
-import org.apache.rocketmq.client.producer.SendCallback;
-import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.*;
 import org.apache.rocketmq.client.producer.selector.SelectMessageQueueByHash;
 import org.apache.rocketmq.common.message.MessageConst;
 import org.springframework.beans.factory.DisposableBean;
@@ -62,6 +63,8 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
     @Getter
     @Setter
     private MessageQueueSelector messageQueueSelector = new SelectMessageQueueByHash();
+
+    private final Map<String, TransactionMQProducer> cache = new ConcurrentHashMap<>(); //only put TransactionMQProducer by now!!!
 
     /**
      * <p> Send message in synchronous mode. This method returns only when the sending procedure totally completes.
@@ -506,5 +509,92 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
         if (Objects.nonNull(producer)) {
             producer.shutdown();
         }
+        for (Map.Entry<String, TransactionMQProducer> kv:cache.entrySet()) {
+            kv.getValue().shutdown();
+        }
+        cache.clear();
+    }
+
+    private TransactionMQProducer stageMQProducer(String name) throws MQClientException {
+        TransactionMQProducer cachedProducer = cache.get(name);
+        if (cachedProducer == null) {
+            throw new MQClientException(-1,
+                String.format("Can not found MQProducer '%s' in cache! please invoke createOrGetStartedTransactionMQProducer() to create it firstly", name));
+        }
+
+        return cachedProducer;
+    }
+
+    /**
+     * Send Message in Transaction
+     * @param txProducerName the validate txProducer name
+     * @param rocketMsg
+     * @param arg
+     * @return
+     * @throws MQClientException
+     */
+    public TransactionSendResult sendMessageInTransaction(final String txProducerName, final org.apache.rocketmq.common.message.Message rocketMsg, final Object arg) throws MQClientException
+    {
+        TransactionMQProducer txProducer = this.stageMQProducer(txProducerName);
+        return txProducer.sendMessageInTransaction(rocketMsg, arg);
+    }
+
+    /**
+     * Remove a TransactionMQProducer from cache by manual.
+     * Note: RocketMQTemplate will shutdown and clear all cached producers when destroying.
+     * @param name
+     * @throws MQClientException
+     */
+    public void removeTransactionMQProducer(String name) throws MQClientException {
+        if (cache.containsKey(name)) {
+            DefaultMQProducer cachedProducer = cache.get(name);
+            cachedProducer.shutdown();
+            cache.remove(name);
+        }
+    }
+
+    /**
+     * Create and start a transaction MQProducer, this new producer will be cached in memory for you fetch out to use next time.
+     * @param name                  Producer (group) name, unique for each producer
+     * @param transactionListener   TransactoinListener impl class
+     * @param executorService       Nullable.
+     * @return  true if producer is created and started; false if the named producer already exists in cache.
+     * @throws MQClientException
+     */
+    public synchronized boolean createAndStartTransactionMQProducer(String name, TransactionListener transactionListener,
+                                                                    ExecutorService executorService) throws MQClientException {
+        if (cache.containsKey(name)) {
+            log.info(String.format("get TransactionMQProducer '%s' from cache", name));
+            return false;
+        }
+
+        // REVIEW ME: set the limitation of total transaction producers?
+        TransactionMQProducer txProducer = createTransactionMQProducer(name, transactionListener, executorService);
+        txProducer.start();
+        cache.put(name, txProducer);
+
+        return true;
+    }
+
+    private TransactionMQProducer createTransactionMQProducer(String name, TransactionListener transactionListener,
+                                                              ExecutorService executorService) {
+        Assert.notNull(producer, "Property 'producer' is required");
+        Assert.notNull(transactionListener, "Parameter 'transactionListener' is required");
+        TransactionMQProducer txProducer = new TransactionMQProducer(name); //TODO RPCHook???
+        txProducer.setTransactionListener(transactionListener);
+
+        txProducer.setNamesrvAddr(producer.getNamesrvAddr());
+        if (executorService!=null) {
+            txProducer.setExecutorService(executorService);
+        }
+
+        txProducer.setSendMsgTimeout(producer.getSendMsgTimeout());
+        txProducer.setRetryTimesWhenSendFailed(producer.getRetryTimesWhenSendFailed());
+        txProducer.setRetryTimesWhenSendAsyncFailed(producer.getRetryTimesWhenSendAsyncFailed());
+        txProducer.setMaxMessageSize(producer.getMaxMessageSize());
+        txProducer.setCompressMsgBodyOverHowmuch(producer.getCompressMsgBodyOverHowmuch());
+        txProducer.setRetryAnotherBrokerWhenNotStoreOK(producer.isRetryAnotherBrokerWhenNotStoreOK());
+
+        return txProducer;
     }
 }

--- a/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTxInternalUtil.java
+++ b/rocketmq-spring-boot-starter/src/main/java/org/apache/rocketmq/spring/starter/core/RocketMQTxInternalUtil.java
@@ -1,0 +1,38 @@
+package org.apache.rocketmq.spring.starter.core;
+
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.TransactionListener;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Create and remove txProducer internally
+ */
+public class RocketMQTxInternalUtil {
+  private RocketMQTemplate rocketMQTemplate;
+
+  private static RocketMQTxInternalUtil instance = null;
+
+  private RocketMQTxInternalUtil(RocketMQTemplate rocketMQTemplate) {
+    this.rocketMQTemplate = rocketMQTemplate;
+  }
+
+  public boolean createAndStartTransactionMQProducer(String name, TransactionListener transactionListener,
+                                              ExecutorService executorService) throws MQClientException {
+    return rocketMQTemplate.createAndStartTransactionMQProducer(name, transactionListener, executorService);
+  }
+
+  public void removeTransactionMQProducer(String name) throws MQClientException {
+    this.rocketMQTemplate.removeTransactionMQProducer(name);
+  }
+
+  public static RocketMQTxInternalUtil create(RocketMQTemplate rocketMQTemplate) {
+    if (instance==null) {
+      synchronized (RocketMQTxInternalUtil.class) {
+        instance = new RocketMQTxInternalUtil(rocketMQTemplate);
+      }
+    }
+
+    return instance;
+  }
+}

--- a/rocketmq-spring-boot-starter/src/test/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfigurationTests.java
+++ b/rocketmq-spring-boot-starter/src/test/java/org/apache/rocketmq/spring/starter/RocketMQAutoConfigurationTests.java
@@ -28,6 +28,7 @@ import org.apache.rocketmq.spring.starter.annotation.RocketMQTransactionListener
 import org.apache.rocketmq.spring.starter.core.DefaultRocketMQListenerContainer;
 import org.apache.rocketmq.spring.starter.core.RocketMQListener;
 import org.apache.rocketmq.spring.starter.core.RocketMQTemplate;
+import org.apache.rocketmq.spring.starter.core.RocketMQTxInternalUtil;
 import org.apache.rocketmq.spring.starter.enums.ConsumeMode;
 import org.apache.rocketmq.spring.starter.enums.SelectorType;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
@@ -83,7 +84,7 @@ public class RocketMQAutoConfigurationTests {
 
         try {
             // create txProducer
-            rocketMQTemplate.createAndStartTransactionMQProducer("test",
+            RocketMQTxInternalUtil.create(rocketMQTemplate).createAndStartTransactionMQProducer("test",
                 new TransactionListener() {
                 @Override
                 public LocalTransactionState executeLocalTransaction(Message msg, Object arg) {
@@ -201,7 +202,7 @@ public class RocketMQAutoConfigurationTests {
         RocketMQTemplate rocketMQTemplate = this.context.getBean(RocketMQTemplate.class);
         try {
             rocketMQTemplate.sendMessageInTransaction(null, new Message(TEST_TOPIC, "Hello".getBytes()), null);
-            rocketMQTemplate.removeTransactionMQProducer(null);
+            RocketMQTxInternalUtil.create(rocketMQTemplate).removeTransactionMQProducer(null);
         } catch (MQClientException e) {
             e.printStackTrace(System.out);
             fail("failed to get TransactionListenerImpl and send transactional msg!");


### PR DESCRIPTION
## What is the purpose of the change

RocketMQ has supported the transaction message in version 4.4.0, but the rocketmq-spring-boot-starter has no the related support yet.

## Brief changelog

XX

## Verifying this change

Tested it with a spring-boot application, main logic at the following:
1.  Producer side:
```
@SpringBootApplication
public class ProducerApplication implements CommandLineRunner {
    private static final String TRANS_NAME = "myTxProducerGroup";
    @Resource
    private RocketMQTemplate rocketMQTemplate;

    public static void main(String[] args) {
        SpringApplication.run(ProducerApplication.class, args);
    }

    @Override
    public void run(String... args) throws Exception {
        testTransaction();
    }


    private void testTransaction() throws MQClientException {
        String[] tags = new String[] {"TagA", "TagB", "TagC", "TagD", "TagE"};
        for (int i = 0; i < 10; i++) {
            try {

                org.apache.rocketmq.common.message.Message msg =
                    new org.apache.rocketmq.common.message.Message("string-topic", tags[i % tags.length], "KEY" + i,
                        ("Hello RocketMQ " + i).getBytes(RemotingHelper.DEFAULT_CHARSET));
                System.out.printf("send msg body = %s%n",new String(msg.getBody()));
                SendResult sendResult = rocketMQTemplate.sendMessageInTransaction(TRANS_NAME, msg, null);
                System.out.printf("XXXXX:   %s%n", sendResult);

                Thread.sleep(10);
            } catch (Exception e) {
                e.printStackTrace();
            }
        }

    }

    @RocketMQTransactionListener(transName = TRANS_NAME)
    class TransactionListenerImpl implements TransactionListener {
        private AtomicInteger transactionIndex = new AtomicInteger(0);

        private ConcurrentHashMap<String, Integer> localTrans = new ConcurrentHashMap<String, Integer>();

        @Override
        public LocalTransactionState executeLocalTransaction(Message msg, Object arg) {
            int value = transactionIndex.getAndIncrement();
            int status = value % 3;
            localTrans.put(msg.getTransactionId(), status);
            return LocalTransactionState.UNKNOW;
        }

        @Override
        public LocalTransactionState checkLocalTransaction(MessageExt msg) {
            Integer status = localTrans.get(msg.getTransactionId());
            if (null != status) {
                switch (status) {
                    case 0:
                        return LocalTransactionState.UNKNOW;
                    case 1:
                        return LocalTransactionState.COMMIT_MESSAGE;
                    case 2:
                        return LocalTransactionState.ROLLBACK_MESSAGE;
                }
            }
            return LocalTransactionState.COMMIT_MESSAGE;
        }
    }
}

```

2. Consumer Side:
```
@SpringBootApplication
public class ConsumerApplication {

    public static void main(String[] args) {
        SpringApplication.run(ConsumerApplication.class, args);
    }
}


@Slf4j
@Service
@RocketMQMessageListener(topic = "${spring.rocketmq.topic}", consumerGroup = "string_consumer")
class StringConsumer implements RocketMQListener<String> {
    @Override
    public void onMessage(String message) {
        log.info("------- StringConsumer received: {}", message);
    }
}
```