### PR TITLE
[ISSUE 306][Flink] Support consume/produce from/to different cluster in the same process.

### DIFF
--- a/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSink.java
+++ b/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSink.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+import java.util.UUID;
 
 import org.apache.commons.lang.Validate;
 import org.apache.flink.configuration.Configuration;
@@ -87,7 +88,7 @@ public class RocketMQSink<IN> extends RichSinkFunction<IN> implements Checkpoint
         Validate.notNull(serializationSchema, "KeyValueSerializationSchema can not be null");
 
         producer = new DefaultMQProducer();
-        producer.setInstanceName(String.valueOf(getRuntimeContext().getIndexOfThisSubtask()));
+        producer.setInstanceName(String.valueOf(getRuntimeContext().getIndexOfThisSubtask()) + "_" + UUID.randomUUID());
         RocketMQConfig.buildProducerConfigs(props, producer);
 
         batchList = new LinkedList<>();

--- a/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSource.java
+++ b/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSource.java
@@ -19,10 +19,7 @@
 package org.apache.rocketmq.flink;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang.Validate;
@@ -115,7 +112,7 @@ public class RocketMQSource<OUT> extends RichParallelSourceFunction<OUT>
         pullConsumerScheduleService = new MQPullConsumerScheduleService(group);
         consumer = pullConsumerScheduleService.getDefaultMQPullConsumer();
 
-        consumer.setInstanceName(String.valueOf(getRuntimeContext().getIndexOfThisSubtask()));
+        consumer.setInstanceName(String.valueOf(getRuntimeContext().getIndexOfThisSubtask()) + "_" + UUID.randomUUID());
         RocketMQConfig.buildConsumerConfigs(props, consumer);
     }
 

--- a/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSource.java
+++ b/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSource.java
@@ -19,7 +19,11 @@
 package org.apache.rocketmq.flink;
 
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang.Validate;


### PR DESCRIPTION
## What is the purpose of the change

Fix [ISSUE 306](https://github.com/apache/rocketmq-externals/issues/306)

When a job consumes messages from ClusterA and sends messages to ClusterB.  Because Flink operators may be chained, the consumer and producer is possible running in the same JVM process. The default instanceName creator creates the same instanceName for the producer and consumer, then the messages will be not sent to the ClusterB. 



## Brief changelog
Add setInstanceName method to Sink and Source, so the user could set the custom instanceName. 

