### PR TITLE
[ISSUE #337] throw exception when send message to broker fail

### DIFF
--- a/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSink.java
+++ b/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSink.java
@@ -140,6 +140,7 @@ public class RocketMQSink<IN> extends RichSinkFunction<IN> implements Checkpoint
                 LOG.debug("Sync send message result: {}", result);
             } catch (Exception e) {
                 LOG.error("Sync send message failure!", e);
+                throw e;
             }
         }
     }

--- a/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSink.java
+++ b/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.rocketmq.flink;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
@@ -34,9 +35,11 @@ import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.client.producer.SendCallback;
 import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.flink.common.selector.TopicSelector;
 import org.apache.rocketmq.flink.common.serialization.KeyValueSerializationSchema;
+import org.apache.rocketmq.remoting.exception.RemotingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,6 +141,9 @@ public class RocketMQSink<IN> extends RichSinkFunction<IN> implements Checkpoint
             try {
                 SendResult result = producer.send(msg);
                 LOG.debug("Sync send message result: {}", result);
+                if (result.getSendStatus() != SendStatus.SEND_OK) {
+                    throw new RemotingException(result.toString());
+                }
             } catch (Exception e) {
                 LOG.error("Sync send message failure!", e);
                 throw e;

--- a/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSink.java
+++ b/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/RocketMQSink.java
@@ -18,7 +18,6 @@
 
 package org.apache.rocketmq.flink;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;


### PR DESCRIPTION
## What is the purpose of the change

FIX [ISSUE 337](https://github.com/apache/rocketmq-externals/issues/337)

## Brief changelog

Rethrow exception when sending message to broker fail.


