### PR TITLE
[rocketmq-console] Refine the message when create or update consumer monitor

### DIFF
--- a/rocketmq-console/src/main/resources/static/src/consumer.js
+++ b/rocketmq-console/src/main/resources/static/src/consumer.js
@@ -283,7 +283,7 @@ module.controller('consumerMonitorDialogController', function ($scope, ngDialog,
                     maxDiffTotal:$scope.ngDialogData.data.maxDiffTotal}
             }).success(function (resp) {
                 if(resp.status ==0){
-                    Notification.info({message: "delete success!", delay: 2000});
+                    Notification.info({message: "update success!", delay: 2000});
                 }else {
                     Notification.error({message: resp.errMsg, delay: 2000});
                 }


### PR DESCRIPTION
## What is the purpose of the change
Change the message when create or update consumer monitor is success to avoid misleading. 

## Brief changelog
Change the word from delete to update