### PR TITLE
fix message trace bug of console: timestamp is now at subAfter record

### DIFF
--- a/rocketmq-console/src/main/java/org/apache/rocketmq/console/model/MessageTraceView.java
+++ b/rocketmq-console/src/main/java/org/apache/rocketmq/console/model/MessageTraceView.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.rocketmq.client.trace.TraceBean;
 import org.apache.rocketmq.client.trace.TraceContext;
+import org.apache.rocketmq.client.trace.TraceType;
 import org.apache.rocketmq.console.util.MsgTraceDecodeUtil;
 
 public class MessageTraceView {
@@ -32,7 +33,7 @@ public class MessageTraceView {
     private int costTime;
     private String msgType;
     private String offSetMsgId;
-    private long timeStamp;
+    private Long timeStamp;
     private String topic;
     private String groupName;
     private String status;
@@ -65,7 +66,9 @@ public class MessageTraceView {
             messageTraceView.setTopic(traceBean.getTopic());
             messageTraceView.setMsgType(context.getTraceType().name());
             messageTraceView.setOffSetMsgId(traceBean.getOffsetMsgId());
-            messageTraceView.setTimeStamp(context.getTimeStamp());
+            if (!messageTraceView.getMsgType().equals(TraceType.SubAfter.name())) {
+                messageTraceView.setTimeStamp(context.getTimeStamp());
+            }
             messageTraceView.setStoreHost(traceBean.getStoreHost());
             messageTraceViewList.add(messageTraceView);
         }
@@ -128,7 +131,7 @@ public class MessageTraceView {
         this.offSetMsgId = offSetMsgId;
     }
 
-    public long getTimeStamp() {
+    public Long getTimeStamp() {
         return timeStamp;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

消息轨迹中，对于SubAfter的轨迹记录是没有时间的，而控制台查询接口，返回的时间戳是当前时间。

## Brief changelog

SubAfter的轨迹记录中timestamp设置为null

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
