### PR TITLE
fix(rocketmq-console): remove unused imports in order to avoid buildi…

### DIFF
--- a/rocketmq-console/src/main/java/org/apache/rocketmq/console/App.java
+++ b/rocketmq-console/src/main/java/org/apache/rocketmq/console/App.java
@@ -17,7 +17,6 @@
 package org.apache.rocketmq.console;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.ServletComponentScan;
 


### PR DESCRIPTION
## What is the reason of the change
- **Conflict with checkstyle file when building [rocketmq-console] module**

***rmq_checkstyle.xml***
```xml
<module name="UnusedImports">
    <property name="processJavadoc" value="true"/>
</module>
```

- **So, please remove unused imports**

***org.apache.rocketmq.console.App***
```java
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
```