### PR TITLE
[ISSUE #573](rocketmq-flume)Replace the DefaultMQPullConsumer with the DefaultLitePullConsumer

### DIFF
--- a/rocketmq-flume/pom.xml
+++ b/rocketmq-flume/pom.xml
@@ -37,7 +37,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <flume.version>1.8.0</flume.version>
-        <rocketmq.version>4.2.0</rocketmq.version>
+        <rocketmq.version>4.7.0</rocketmq.version>
     </properties>
     <dependencies>
         <dependency>

--- a/rocketmq-flume/rocketmq-flume-source/src/main/java/org/apache/rocketmq/flume/ng/source/RocketMQSource.java
+++ b/rocketmq-flume/rocketmq-flume-source/src/main/java/org/apache/rocketmq/flume/ng/source/RocketMQSource.java
@@ -17,18 +17,10 @@
 
 package org.apache.rocketmq.flume.ng.source;
 
-import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
-import org.apache.rocketmq.client.consumer.PullResult;
-import org.apache.rocketmq.client.consumer.PullStatus;
-import org.apache.rocketmq.client.exception.MQClientException;
-import org.apache.rocketmq.common.message.MessageExt;
-import org.apache.rocketmq.common.message.MessageQueue;
-import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
@@ -38,6 +30,11 @@ import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.source.AbstractPollableSource;
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +69,7 @@ public class RocketMQSource extends AbstractPollableSource implements Configurab
     /** Monitoring counter. */
     private SourceCounter sourceCounter;
 
-    DefaultMQPullConsumer consumer;
+    DefaultLitePullConsumer consumer;
 
     @Override protected void doConfigure(Context context) throws FlumeException {
 
@@ -95,12 +92,12 @@ public class RocketMQSource extends AbstractPollableSource implements Configurab
     @Override
     protected void doStart() throws FlumeException {
 
-        consumer = new DefaultMQPullConsumer(consumerGroup);
+        consumer = new DefaultLitePullConsumer(consumerGroup);
         consumer.setNamesrvAddr(nameServer);
         consumer.setMessageModel(MessageModel.valueOf(messageModel));
-        consumer.registerMessageQueueListener(topic, null);
-
+        consumer.setPullBatchSize(batchSize);
         try {
+            consumer.subscribe(topic, tag);
             consumer.start();
         } catch (MQClientException e) {
             log.error("RocketMQ consumer start failed", e);
@@ -119,31 +116,19 @@ public class RocketMQSource extends AbstractPollableSource implements Configurab
         Map<String, String> headers;
 
         try {
-            Set<MessageQueue> queues = consumer.fetchSubscribeMessageQueues(topic);
-            for (MessageQueue queue : queues) {
-                long offset = getMessageQueueOffset(queue);
-                PullResult pullResult = consumer.pull(queue, tag, offset, batchSize);
+            List<MessageExt> messageExts = consumer.poll();
+            for (MessageExt msg : messageExts) {
+                byte[] body = msg.getBody();
 
+                headers = new HashMap<>();
+                headers.put(HEADER_TOPIC_NAME, topic);
+                headers.put(HEADER_TAG_NAME, tag);
                 if (log.isDebugEnabled()) {
-                    log.debug("Pull from queueId:{}, offset:{}, pullResult:{}", queue.getQueueId(), offset, pullResult);
+                    log.debug("Processing message,body={}", new String(body, "UTF-8"));
                 }
 
-                if (pullResult.getPullStatus() == PullStatus.FOUND) {
-                    for (MessageExt msg : pullResult.getMsgFoundList()) {
-                        byte[] body = msg.getBody();
-
-                        headers = new HashMap<>();
-                        headers.put(HEADER_TOPIC_NAME, topic);
-                        headers.put(HEADER_TAG_NAME, tag);
-                        if (log.isDebugEnabled()) {
-                            log.debug("Processing message,body={}", new String(body, "UTF-8"));
-                        }
-
-                        event = EventBuilder.withBody(body, headers);
-                        events.add(event);
-                    }
-                    offsets.put(queue, pullResult.getNextBeginOffset());
-                }
+                event = EventBuilder.withBody(body, headers);
+                events.add(event);
             }
 
             if (events.size() > 0) {
@@ -156,10 +141,6 @@ public class RocketMQSource extends AbstractPollableSource implements Configurab
                 sourceCounter.addToEventAcceptedCount(events.size());
 
                 events.clear();
-            }
-
-            for (Map.Entry<MessageQueue, Long> entry : offsets.entrySet()) {
-                putMessageQueueOffset(entry.getKey(), entry.getValue());
             }
 
         } catch (Exception e) {
@@ -175,18 +156,5 @@ public class RocketMQSource extends AbstractPollableSource implements Configurab
         sourceCounter.stop();
 
         consumer.shutdown();
-    }
-
-    private long getMessageQueueOffset(MessageQueue queue) throws MQClientException {
-        long offset = consumer.fetchConsumeOffset(queue, false);
-        if (offset < 0) {
-            offset = 0;
-        }
-
-        return offset;
-    }
-
-    private void putMessageQueueOffset(MessageQueue queue, long offset) throws MQClientException {
-        consumer.updateConsumeOffset(queue, offset);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

DefaultMQPullConsumer is deprecated after RMQ Version 4.6.0. A better implementation DefaultLitePullConsumer is recommend to use in the scenario of actively pulling messages. We can use it.

## Brief changelog

Replace the DefaultMQPullConsumer with the DefaultLitePullConsumer

## Verifying this change

Yes

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
