### PR TITLE
Showcase the group name on the detail dialog of message trace

### DIFF
--- a/rocketmq-console/src/main/resources/static/view/pages/messageTrace.html
+++ b/rocketmq-console/src/main/resources/static/view/pages/messageTrace.html
@@ -137,6 +137,7 @@
                     <th class="text-center">Message ID</th>
                     <th class="text-center">Tag</th>
                     <th class="text-center">Message Key</th>
+                    <th class="text-center">Group</th>
                     <th class="text-center">StoreTime</th>
                     <th class="text-center">StoreHost</th>
                     <th class="text-center">costTime</th>
@@ -147,6 +148,7 @@
                     <td class="text-center">{{item.msgId}}</td>
                     <td class="text-center">{{item.tags}}</td>
                     <td class="text-center">{{item.keys}}</td>
+                    <td class="text-center">{{item.groupName}}</td>
                     <td class="text-center">{{item.timeStamp | date:'yyyy-MM-dd HH:mm:ss'}}</td>
                     <td class="text-center">{{item.storeHost}}</td>
                     <td class="text-center">{{item.costTime}}ms</td>


### PR DESCRIPTION
## What is the purpose of the change

Locate the consume related issues quickly.

## Brief changelog

Add one more column Group with the property groupName

## Verifying this change

Open the message trace page, query a message via id / key, we could see the group name column on the detail dialog.
