### PR TITLE
update aspectj version

### DIFF
--- a/rocketmq-console/pom.xml
+++ b/rocketmq-console/pom.xml
@@ -65,7 +65,7 @@
         <commons-cli.version>1.2</commons-cli.version>
         <rocketmq.version>4.7.1</rocketmq.version>
         <surefire.version>2.19.1</surefire.version>
-        <aspectj.version>1.8.10</aspectj.version>
+        <aspectj.version>1.9.6</aspectj.version>
         <main.basedir>${basedir}/../..</main.basedir>
         <docker.image.prefix>apacherocketmq</docker.image.prefix>
         <spring.boot.version>2.2.2.RELEASE</spring.boot.version>


### PR DESCRIPTION
Exception: ::0 can't find referenced pointcut mQAdminMethodPointCut
update aspectj version is ok

## What is the purpose of the change

Exception: ::0 can't find referenced pointcut mQAdminMethodPointCut

## Brief changelog

update aspectj version to 1.9.6

## Verifying this change

Tomcat started on port(s): 8080 (http) with context path ''