### PR TITLE
[#786] RocketMQSourceFunction supports the close of ExecutorService and ScheduledExecutorService

### DIFF
--- a/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/legacy/RocketMQSourceFunction.java
+++ b/rocketmq-flink/src/main/java/org/apache/rocketmq/flink/legacy/RocketMQSourceFunction.java
@@ -376,18 +376,32 @@ public class RocketMQSourceFunction<OUT> extends RichParallelSourceFunction<OUT>
         log.debug("cancel ...");
         runningChecker.setRunning(false);
 
+        if (timer != null) {
+            timer.shutdown();
+            timer = null;
+        }
+
+        if (executor != null) {
+            executor.shutdown();
+            executor = null;
+        }
+
         if (consumer != null) {
             consumer.shutdown();
+            consumer = null;
         }
 
         if (offsetTable != null) {
             offsetTable.clear();
+            offsetTable = null;
         }
         if (restoredOffsets != null) {
             restoredOffsets.clear();
+            restoredOffsets = null;
         }
         if (pendingOffsetsToCommit != null) {
             pendingOffsetsToCommit.clear();
+            pendingOffsetsToCommit = null;
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

`RocketMQSourceFunction` should support the close of `ExecutorService` and `ScheduledExecutorService` which should be closed when the `SourceOperator` closes.

## Brief changelog

- Add the close of `ExecutorService` and `ScheduledExecutorService` in the`RocketMQSourceFunction#close`.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
