### PR TITLE
[ISSUE #798] fields will not be built in SinkDataEntry

### DIFF
--- a/rocketmq-connect/rocketmq-connect-runtime/src/main/java/org/apache/rocketmq/connect/runtime/connectorwrapper/WorkerSinkTask.java
+++ b/rocketmq-connect/rocketmq-connect-runtime/src/main/java/org/apache/rocketmq/connect/runtime/connectorwrapper/WorkerSinkTask.java
@@ -430,13 +430,13 @@ public class WorkerSinkTask implements WorkerTask {
         dataEntryBuilder.entryType(entryType);
         dataEntryBuilder.queue(queueName);
         dataEntryBuilder.timestamp(timestamp);
-        SinkDataEntry sinkDataEntry = dataEntryBuilder.buildSinkDataEntry(message.getQueueOffset());
         List<Field> fields = schema.getFields();
         if (null != fields && !fields.isEmpty()) {
             for (Field field : fields) {
                 dataEntryBuilder.putFiled(field.getName(), datas[field.getIndex()]);
             }
         }
+        SinkDataEntry sinkDataEntry = dataEntryBuilder.buildSinkDataEntry(message.getQueueOffset());
         return sinkDataEntry;
     }
 


### PR DESCRIPTION
## What is the purpose of the change
fields put after SinkDataEntry built, SinkDataEntry will include fields.
```java
        SinkDataEntry sinkDataEntry = dataEntryBuilder.buildSinkDataEntry(message.getQueueOffset()); 
        List<Field> fields = schema.getFields();
        if (null != fields && !fields.isEmpty()) {
            for (Field field : fields) {
                dataEntryBuilder.putFiled(field.getName(), datas[field.getIndex()]);
            }
        }
        return sinkDataEntry;
```