### PR TITLE
Systemctl parameter optimization

### DIFF
--- a/rocketmq-ansible/roles/broker/templates/mqbroker.service
+++ b/rocketmq-ansible/roles/broker/templates/mqbroker.service
@@ -24,6 +24,9 @@ ExecStart=/bin/bash -c 'source /etc/profile && {{ rocketmq_deploy_path }}/rocket
 ExecStop=/bin/bash -c 'source /etc/profile && {{ rocketmq_deploy_path }}/rocketmq/bin/mqshutdown broker'
 RemainAfterExit=yes
 
+LimitNOFILE=655350
+LimitMEMLOCK=infinity
+
 Restart=always
 RestartSec=5s
 [Install]


### PR DESCRIPTION
When the host is restarting（For example: runing reboot command）, It using /etc/systemd/system.conf instead of os parameter.