### PR TITLE
Some improvements about rocketmq-spark

### DIFF
--- a/rocketmq-spark/pom.xml
+++ b/rocketmq-spark/pom.xml
@@ -86,6 +86,12 @@
             <version>4.12</version>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-namesrv</artifactId>
             <version>${rocketmq.version}</version>

--- a/rocketmq-spark/pom.xml
+++ b/rocketmq-spark/pom.xml
@@ -33,7 +33,7 @@
         <!-- compiler settings properties -->
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <rocketmq.version>4.2.0</rocketmq.version>
+        <rocketmq.version>4.9.4</rocketmq.version>
         <spark.version>2.3.0</spark.version>
         <scala.version>2.11.8</scala.version>
         <scala.binary.version>2.11</scala.binary.version>

--- a/rocketmq-spark/pom.xml
+++ b/rocketmq-spark/pom.xml
@@ -106,6 +106,14 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>META-INF/services/*.*</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/RocketMQConfig.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/RocketMQConfig.java
@@ -43,7 +43,7 @@ public class RocketMQConfig {
     public static final String DEFAULT_CLIENT_IP = RemotingUtil.getLocalAddress();
 
     public static final String CLIENT_CALLBACK_EXECUTOR_THREADS = "client.callback.executor.threads";
-    public static final int DEFAULT_CLIENT_CALLBACK_EXECUTOR_THREADS = Runtime.getRuntime().availableProcessors();;
+    public static final int DEFAULT_CLIENT_CALLBACK_EXECUTOR_THREADS = Runtime.getRuntime().availableProcessors();
 
     public static final String NAME_SERVER_POLL_INTERVAL = "nameserver.poll.interval";
     public static final int DEFAULT_NAME_SERVER_POLL_INTERVAL = 30000; // 30 seconds

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/RocketMQConfig.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/RocketMQConfig.java
@@ -31,6 +31,10 @@ import java.util.UUID;
  * RocketMQConfig for Consumer
  */
 public class RocketMQConfig {
+
+    public static final String MQ_PULL_CONSUMER_PROVIDER_FACTORY_NAME = "mq.pull.consumer.provider.factory.name";
+    public static final String DEFAULT_MQ_PULL_CONSUMER_PROVIDER_FACTORY_NAME = "DefaultSimpleFactory";
+
     // ------- the following is for common usage -------
     /**
      * RocketMq name server address

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/DefaultMessageRetryManager.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/DefaultMessageRetryManager.java
@@ -26,8 +26,8 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * An implementation of MessageRetryManager
  */
-public class DefaultMessageRetryManager implements MessageRetryManager{
-    private Map<String,MessageSet> cache = new ConcurrentHashMap<>(500);
+public class DefaultMessageRetryManager implements MessageRetryManager {
+    private Map<String, MessageSet> cache = new ConcurrentHashMap<>(500);
     private BlockingQueue<MessageSet> queue;
     private int maxRetry;
     private int ttl;
@@ -88,7 +88,7 @@ public class DefaultMessageRetryManager implements MessageRetryManager{
     }
 
     // just for testing
-    public void setCache(Map<String,MessageSet> cache) {
+    public void setCache(Map<String, MessageSet> cache) {
         this.cache = cache;
     }
 }

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MQPullConsumerProvider.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MQPullConsumerProvider.java
@@ -28,39 +28,78 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * @Description TODO
- * @Author zhaorongsheng
- * @Date 2022/10/5 21:48
- * @Version 1.0
+ * Custom pull consumer interface
  */
 public interface MQPullConsumerProvider {
 
+    /**
+     * Set rocket mq consumer group.
+     */
     void setConsumerGroup(String consumerGroup);
 
-    void setOptionParams(Map<String, String> optionParams);
-
+    /**
+     * Set consumer timeout.
+     */
     void setConsumerTimeoutMillisWhenSuspend(long consumerTimeoutMillisWhenSuspend);
 
+    /**
+     * Set consumer instance name.
+     */
     void setInstanceName(String instanceName);
 
+    /**
+     * Set name server address.
+     */
     void setNamesrvAddr(String namesrvAddr);
 
+    /**
+     * Set options params.
+     */
+    void setOptionParams(Map<String, String> optionParams);
+
+    /**
+     * Start consumer.
+     */
     void start() throws MQClientException;
 
-    void setOffsetStore(OffsetStore offsetStore);
-
+    /**
+     * Get offset store.
+     * @return
+     */
     OffsetStore getOffsetStore();
 
+    /**
+     * Set offset store.
+     *
+     * It is called with getOffsetStore().
+     */
+    void setOffsetStore(OffsetStore offsetStore);
+
+    /**
+     * Pull messages from specified MessageQueue with subExpression, offset and maxNums.
+     */
     PullResult pull(MessageQueue mq, String subExpression, long offset, int maxNums)
         throws MQClientException, RemotingException, MQBrokerException, InterruptedException;
 
+    /**
+     * Get all MessageQueues from the specified topic.
+     */
     Set<MessageQueue> fetchSubscribeMessageQueues(String topic) throws MQClientException;
 
+    /**
+     * Get the minimum offset of the specified MessageQueue.
+     */
     long minOffset(MessageQueue mq) throws MQClientException;
 
+    /**
+     * Get the maximum offset of the specified MessageQueue.
+     */
     long maxOffset(MessageQueue mq) throws MQClientException;
 
-    void updateConsumeOffset(MessageQueue mq, long offset) throws MQClientException;
+    /**
+     * Commit offset of the specified MessageQueue
+     */
+    void commitConsumeOffset(MessageQueue mq, long offset) throws MQClientException;
 
     void shutdown();
 }

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MQPullConsumerProvider.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MQPullConsumerProvider.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.spark.streaming;
+
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.store.OffsetStore;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @Description TODO
+ * @Author zhaorongsheng
+ * @Date 2022/10/5 21:48
+ * @Version 1.0
+ */
+public interface MQPullConsumerProvider {
+
+    void setConsumerGroup(String consumerGroup);
+
+    void setOptionParams(Map<String, String> optionParams);
+
+    void setConsumerTimeoutMillisWhenSuspend(long consumerTimeoutMillisWhenSuspend);
+
+    void setInstanceName(String instanceName);
+
+    void setNamesrvAddr(String namesrvAddr);
+
+    void start() throws MQClientException;
+
+    void setOffsetStore(OffsetStore offsetStore);
+
+    OffsetStore getOffsetStore();
+
+    PullResult pull(MessageQueue mq, String subExpression, long offset, int maxNums)
+        throws MQClientException, RemotingException, MQBrokerException, InterruptedException;
+
+    Set<MessageQueue> fetchSubscribeMessageQueues(String topic) throws MQClientException;
+
+    long minOffset(MessageQueue mq) throws MQClientException;
+
+    long maxOffset(MessageQueue mq) throws MQClientException;
+
+    void updateConsumeOffset(MessageQueue mq, long offset) throws MQClientException;
+
+    void shutdown();
+}

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MQPullConsumerProviderFactory.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MQPullConsumerProviderFactory.java
@@ -18,10 +18,7 @@
 package org.apache.rocketmq.spark.streaming;
 
 /**
- * @Description TODO
- * @Author zhaorongsheng
- * @Date 2022/10/5 23:22
- * @Version 1.0
+ * Pull consumer provider factory interface
  */
 public interface MQPullConsumerProviderFactory {
     String getName();

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MQPullConsumerProviderFactory.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MQPullConsumerProviderFactory.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.spark.streaming;
+
+/**
+ * @Description TODO
+ * @Author zhaorongsheng
+ * @Date 2022/10/5 23:22
+ * @Version 1.0
+ */
+public interface MQPullConsumerProviderFactory {
+    String getName();
+
+    MQPullConsumerProvider build();
+}

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MessageSet.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/MessageSet.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 /**
  * A message collection.
  */
-public class MessageSet implements Iterator<Message>, Serializable{
+public class MessageSet implements Iterator<Message>, Serializable {
     private final String id;
     private final List<MessageExt> data;
     private final Iterator<MessageExt> iterator;

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/RocketMQReceiver.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/RocketMQReceiver.java
@@ -60,7 +60,7 @@ public class RocketMQReceiver extends Receiver<Message> {
         ordered = RocketMQConfig.getBoolean(properties, RocketMQConfig.CONSUMER_MESSAGES_ORDERLY, false);
 
         consumer = new DefaultMQPushConsumer();
-        RocketMQConfig.buildConsumerConfigs(properties, (DefaultMQPushConsumer)consumer);
+        RocketMQConfig.buildConsumerConfigs(properties, (DefaultMQPushConsumer) consumer);
 
         if (ordered) {
             consumer.registerMessageListener(new MessageListenerOrderly() {

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/RocketMQReceiver.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/RocketMQReceiver.java
@@ -32,6 +32,8 @@ import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.spark.RocketMQConfig;
 import org.apache.spark.storage.StorageLevel;
 import org.apache.spark.streaming.receiver.Receiver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Properties;
@@ -45,6 +47,8 @@ import java.util.Properties;
  * Recommend to use ReliableRocketMQReceiver which is fault-tolerance guarantees.
  */
 public class RocketMQReceiver extends Receiver<Message> {
+    private static final Logger LOG = LoggerFactory.getLogger(RocketMQReceiver.class);
+
     protected MQPushConsumer consumer;
     protected boolean ordered;
     protected Properties properties;
@@ -91,7 +95,15 @@ public class RocketMQReceiver extends Receiver<Message> {
         try {
             consumer.start();
         } catch (MQClientException e) {
-            throw new RuntimeException(e);
+            // TODO add retry
+            LOG.error("Failed to start rocketmq consumer because of client exception", e);
+            throw new InternalError(e);
+        } catch (Exception e) {
+            // should not throw spark NonFatal error here
+            LOG.error("Failed to start rocketmq consumer because of other exception", e);
+            throw new InternalError(e);
+        } finally {
+            LOG.error("error when consumer start", "xx");
         }
     }
 

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/SimpleMQPullConsumerProvider.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/SimpleMQPullConsumerProvider.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.spark.streaming;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.consumer.store.OffsetStore;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @Description TODO
+ * @Author zhaorongsheng
+ * @Date 2022/10/5 21:53
+ * @Version 1.0
+ */
+public class SimpleMQPullConsumerProvider implements MQPullConsumerProvider {
+    private DefaultMQPullConsumer consumer;
+
+    public SimpleMQPullConsumerProvider() {
+        consumer = new DefaultMQPullConsumer();
+    }
+
+    @Override
+    public void setConsumerGroup(String consumerGroup) {
+        consumer.setConsumerGroup(consumerGroup);
+    }
+
+    @Override
+    public void setOptionParams(Map<String, String> optionParams) {
+
+    }
+
+    @Override
+    public void setConsumerTimeoutMillisWhenSuspend(long consumerTimeoutMillisWhenSuspend) {
+        consumer.setConsumerTimeoutMillisWhenSuspend(consumerTimeoutMillisWhenSuspend);
+    }
+
+    @Override
+    public void setInstanceName(String instanceName) {
+        consumer.setInstanceName(instanceName);
+    }
+
+    @Override
+    public void setNamesrvAddr(String namesrvAddr) {
+        consumer.setNamesrvAddr(namesrvAddr);
+    }
+
+    @Override
+    public void start() throws MQClientException {
+        consumer.start();
+    }
+
+    @Override
+    public void setOffsetStore(OffsetStore offsetStore) {
+        consumer.setOffsetStore(offsetStore);
+    }
+
+    @Override
+    public OffsetStore getOffsetStore() {
+        return consumer.getDefaultMQPullConsumerImpl().getOffsetStore();
+    }
+
+    @Override
+    public PullResult pull(MessageQueue mq, String subExpression, long offset, int maxNums)
+            throws MQBrokerException, RemotingException, InterruptedException, MQClientException {
+        return consumer.pull(mq, subExpression, offset, maxNums);
+    }
+
+    @Override
+    public Set<MessageQueue> fetchSubscribeMessageQueues(String topic) throws MQClientException {
+        return consumer.fetchSubscribeMessageQueues(topic);
+    }
+
+    @Override
+    public long minOffset(MessageQueue mq) throws MQClientException {
+        return consumer.minOffset(mq);
+    }
+
+    @Override
+    public long maxOffset(MessageQueue mq) throws MQClientException {
+        return consumer.maxOffset(mq);
+    }
+
+    @Override
+    public void updateConsumeOffset(MessageQueue mq, long offset) throws MQClientException {
+        consumer.updateConsumeOffset(mq, offset);
+    }
+
+    @Override
+    public void shutdown() {
+        consumer.shutdown();
+    }
+}

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/SimpleMQPullConsumerProvider.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/SimpleMQPullConsumerProvider.java
@@ -29,10 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * @Description TODO
- * @Author zhaorongsheng
- * @Date 2022/10/5 21:53
- * @Version 1.0
+ * Simple mq pull consumer provider which implemented by DefaultMQPullConsumer
  */
 public class SimpleMQPullConsumerProvider implements MQPullConsumerProvider {
     private DefaultMQPullConsumer consumer;
@@ -48,7 +45,7 @@ public class SimpleMQPullConsumerProvider implements MQPullConsumerProvider {
 
     @Override
     public void setOptionParams(Map<String, String> optionParams) {
-
+        // ignore
     }
 
     @Override
@@ -103,7 +100,7 @@ public class SimpleMQPullConsumerProvider implements MQPullConsumerProvider {
     }
 
     @Override
-    public void updateConsumeOffset(MessageQueue mq, long offset) throws MQClientException {
+    public void commitConsumeOffset(MessageQueue mq, long offset) throws MQClientException {
         consumer.updateConsumeOffset(mq, offset);
     }
 

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/SimpleMQPullConsumerProviderFactory.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/SimpleMQPullConsumerProviderFactory.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.spark.streaming;
+
+import static org.apache.rocketmq.spark.RocketMQConfig.DEFAULT_MQ_PULL_CONSUMER_PROVIDER_FACTORY_NAME;
+
+/**
+ * @Description TODO
+ * @Author zhaorongsheng
+ * @Date 2022/10/5 23:23
+ * @Version 1.0
+ */
+public class SimpleMQPullConsumerProviderFactory implements MQPullConsumerProviderFactory {
+    @Override
+    public String getName() {
+        return DEFAULT_MQ_PULL_CONSUMER_PROVIDER_FACTORY_NAME;
+    }
+
+    @Override
+    public MQPullConsumerProvider build() {
+        return new SimpleMQPullConsumerProvider();
+    }
+}

--- a/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/SimpleMQPullConsumerProviderFactory.java
+++ b/rocketmq-spark/src/main/java/org/apache/rocketmq/spark/streaming/SimpleMQPullConsumerProviderFactory.java
@@ -20,10 +20,7 @@ package org.apache.rocketmq.spark.streaming;
 import static org.apache.rocketmq.spark.RocketMQConfig.DEFAULT_MQ_PULL_CONSUMER_PROVIDER_FACTORY_NAME;
 
 /**
- * @Description TODO
- * @Author zhaorongsheng
- * @Date 2022/10/5 23:23
- * @Version 1.0
+ * Simple mq pull consumer provider factory
  */
 public class SimpleMQPullConsumerProviderFactory implements MQPullConsumerProviderFactory {
     @Override

--- a/rocketmq-spark/src/main/resources/META-INF/services/org.apache.rocketmq.spark.streaming.MQPullConsumerProviderFactory
+++ b/rocketmq-spark/src/main/resources/META-INF/services/org.apache.rocketmq.spark.streaming.MQPullConsumerProviderFactory
@@ -1,0 +1,1 @@
+org.apache.rocketmq.spark.streaming.SimpleMQPullConsumerProviderFactory

--- a/rocketmq-spark/src/main/scala/org/apache/rocketmq/spark/CachedMQConsumer.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/rocketmq/spark/CachedMQConsumer.scala
@@ -19,6 +19,8 @@ package org.apache.rocketmq.spark
 
 import org.apache.rocketmq.client.consumer.{DefaultMQPullConsumer, PullStatus}
 import org.apache.rocketmq.common.message.{MessageExt, MessageQueue}
+import org.apache.rocketmq.spark.streaming.MQPullConsumerProvider
+
 import java.{util => ju}
 
 /**
@@ -28,7 +30,7 @@ import java.{util => ju}
 private[rocketmq]
 class CachedMQConsumer private(
    val groupId: String,
-   val client: DefaultMQPullConsumer,
+   val client: MQPullConsumerProvider,
    val topic: String,
    val queueId: Int,
    val names: Set[String],
@@ -93,7 +95,7 @@ object CachedMQConsumer extends Logging {
   
   private case class CacheKey(groupId: String, topic: String, queueId: Int, names: Set[String])
 
-  private var groupIdToClient = Map[String, DefaultMQPullConsumer]()
+  private var groupIdToClient = Map[String, MQPullConsumerProvider]()
 
   // Don't want to depend on guava, don't want a cleanup thread, use a simple LinkedHashMap
   private var cache: ju.LinkedHashMap[CacheKey, CachedMQConsumer] = null

--- a/rocketmq-spark/src/main/scala/org/apache/rocketmq/spark/ConsumerProvider.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/rocketmq/spark/ConsumerProvider.scala
@@ -1,0 +1,48 @@
+package org.apache.rocketmq.spark
+
+import org.apache.rocketmq.spark.streaming.{MQPullConsumerProvider, MQPullConsumerProviderFactory}
+
+import java.security.InvalidParameterException
+import java.util.ServiceLoader
+import scala.collection.mutable
+
+/**
+ * @Description TODO
+ * @Author zhaorongsheng
+ * @Date 2022/10/5 22:35
+ * @Version 1.0
+ */
+object ConsumerProvider extends Logging {
+    private val pullConsumerProviderFactories = loadPullConsumerProviderFactories()
+
+    private def loadPullConsumerProviderFactories(): Seq[MQPullConsumerProviderFactory] = {
+        val loader = ServiceLoader.load(classOf[MQPullConsumerProviderFactory])
+        val providerFactories = mutable.ArrayBuffer[MQPullConsumerProviderFactory]()
+        val iterator = loader.iterator
+        while (iterator.hasNext) {
+            try {
+                val providerFactory = iterator.next()
+                providerFactories += providerFactory
+                logDebug(s"Loaded consumer provider: ${providerFactory.getName}")
+            } catch {
+                case e: Throwable =>
+                    logError("Failed to load MQPullConsumerProvider", e)
+            }
+        }
+        providerFactories.toSeq
+    }
+
+    def getPullConsumerProviderByFactoryName(factoryName: String): MQPullConsumerProvider = {
+        val providerFactory = pullConsumerProviderFactories.filter(_.getName.equals(factoryName))
+        if (providerFactory.isEmpty || providerFactory.length > 1) {
+            val providerFactoriesStr = providerFactory.map(_.getName).mkString(", ")
+            logError(s"Failed to get MQPullConsumerProviderFactory because of " +
+                s"ambiguous or no satisfied factories: ${providerFactoriesStr}")
+            throw new InvalidParameterException(s"Ambiguous or no satisfied provider factories: " +
+                s"${providerFactoriesStr}")
+        }
+        logDebug(s"Get satisfied MQPullConsumerProverFactory: ${factoryName}")
+        providerFactory.head.build()
+    }
+
+}

--- a/rocketmq-spark/src/main/scala/org/apache/rocketmq/spark/ConsumerProviderFactory.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/rocketmq/spark/ConsumerProviderFactory.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable
  * @Date 2022/10/5 22:35
  * @Version 1.0
  */
-object ConsumerProvider extends Logging {
+object ConsumerProviderFactory extends Logging {
     private val pullConsumerProviderFactories = loadPullConsumerProviderFactories()
 
     private def loadPullConsumerProviderFactories(): Seq[MQPullConsumerProviderFactory] = {
@@ -37,11 +37,11 @@ object ConsumerProvider extends Logging {
         if (providerFactory.isEmpty || providerFactory.length > 1) {
             val providerFactoriesStr = providerFactory.map(_.getName).mkString(", ")
             logError(s"Failed to get MQPullConsumerProviderFactory because of " +
-                s"ambiguous or no satisfied factories: ${providerFactoriesStr}")
-            throw new InvalidParameterException(s"Ambiguous or no satisfied provider factories: " +
-                s"${providerFactoriesStr}")
+                s"ambiguous or no matched factories: ${providerFactoriesStr}")
+            throw new InvalidParameterException(s"Ambiguous or no matched provider factory for " +
+                s"${factoryName}: [${providerFactoriesStr}]")
         }
-        logDebug(s"Get satisfied MQPullConsumerProverFactory: ${factoryName}")
+        logDebug(s"Get matched MQPullConsumerProverFactory: ${factoryName}")
         providerFactory.head.build()
     }
 

--- a/rocketmq-spark/src/main/scala/org/apache/rocketmq/spark/RocketMqUtils.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/rocketmq/spark/RocketMqUtils.scala
@@ -185,7 +185,7 @@ object RocketMqUtils extends Logging {
       instance: String): MQPullConsumerProvider = {
     val consumerProviderFactoryName =
       optionParams.getOrDefault(MQ_PULL_CONSUMER_PROVIDER_FACTORY_NAME, DEFAULT_MQ_PULL_CONSUMER_PROVIDER_FACTORY_NAME)
-    val consumer = ConsumerProvider.getPullConsumerProviderByFactoryName(consumerProviderFactoryName)
+    val consumer = ConsumerProviderFactory.getPullConsumerProviderByFactoryName(consumerProviderFactoryName)
     consumer.setConsumerGroup(groupId)
     if (optionParams.containsKey(PULL_TIMEOUT_MS))
       consumer.setConsumerTimeoutMillisWhenSuspend(optionParams.get(PULL_TIMEOUT_MS).toLong)

--- a/rocketmq-spark/src/main/scala/org/apache/rocketmq/spark/RocketMqUtils.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/rocketmq/spark/RocketMqUtils.scala
@@ -19,9 +19,7 @@ package org.apache.rocketmq.spark
 
 import java.util.Properties
 import java.{lang => jl, util => ju}
-
 import org.apache.commons.lang.StringUtils
-import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer
 import org.apache.rocketmq.common.message.{Message, MessageExt, MessageQueue}
 import org.apache.spark.SparkContext
 import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
@@ -29,10 +27,11 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.api.java.{JavaInputDStream, JavaStreamingContext}
 import org.apache.spark.streaming.dstream.InputDStream
 import org.apache.spark.streaming.{MQPullInputDStream, RocketMqRDD, StreamingContext}
-import org.apache.rocketmq.spark.streaming.{ReliableRocketMQReceiver, RocketMQReceiver}
+import org.apache.rocketmq.spark.RocketMQConfig._
+import org.apache.rocketmq.spark.streaming.{MQPullConsumerProvider, ReliableRocketMQReceiver, RocketMQReceiver, SimpleMQPullConsumerProvider}
 import org.apache.spark.storage.StorageLevel
 
-object RocketMqUtils {
+object RocketMqUtils extends Logging {
 
   /**
     *  Scala constructor for a batch-oriented interface for consuming from rocketmq.
@@ -180,17 +179,24 @@ object RocketMqUtils {
     new JavaInputDStream(inputDStream)
   }
 
-  def mkPullConsumerInstance(groupId: String, optionParams: ju.Map[String, String], instance: String): DefaultMQPullConsumer = {
-    val consumer = new DefaultMQPullConsumer(groupId)
-    if (optionParams.containsKey(RocketMQConfig.PULL_TIMEOUT_MS))
-      consumer.setConsumerTimeoutMillisWhenSuspend(optionParams.get(RocketMQConfig.PULL_TIMEOUT_MS).toLong)
+  def mkPullConsumerInstance(
+      groupId: String,
+      optionParams: ju.Map[String, String],
+      instance: String): MQPullConsumerProvider = {
+    val consumerProviderFactoryName =
+      optionParams.getOrDefault(MQ_PULL_CONSUMER_PROVIDER_FACTORY_NAME, DEFAULT_MQ_PULL_CONSUMER_PROVIDER_FACTORY_NAME)
+    val consumer = ConsumerProvider.getPullConsumerProviderByFactoryName(consumerProviderFactoryName)
+    consumer.setConsumerGroup(groupId)
+    if (optionParams.containsKey(PULL_TIMEOUT_MS))
+      consumer.setConsumerTimeoutMillisWhenSuspend(optionParams.get(PULL_TIMEOUT_MS).toLong)
     if (!StringUtils.isBlank(instance)) 
       consumer.setInstanceName(instance)
-    if (optionParams.containsKey(RocketMQConfig.NAME_SERVER_ADDR))
-      consumer.setNamesrvAddr(optionParams.get(RocketMQConfig.NAME_SERVER_ADDR))
+    if (optionParams.containsKey(NAME_SERVER_ADDR))
+      consumer.setNamesrvAddr(optionParams.get(NAME_SERVER_ADDR))
+    consumer.setOptionParams(optionParams)
 
     consumer.start()
-    consumer.setOffsetStore(consumer.getDefaultMQPullConsumerImpl.getOffsetStore)
+    consumer.setOffsetStore(consumer.getOffsetStore)
     consumer
   }
 

--- a/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/CachedRocketMQConsumer.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/CachedRocketMQConsumer.scala
@@ -374,7 +374,7 @@ private object CachedRocketMQConsumer extends Logging {
     val groupId = options.get(RocketMQConf.CONSUMER_GROUP)
     val client = synchronized {
       groupIdUseCount.getOrElseUpdate(groupId, new MutableInt(0)).increment()
-      groupIdToClient.getOrElseUpdate(groupId, RocketMQUtils.makePullConsumer(groupId, options))
+      groupIdToClient.getOrElseUpdate(groupId, RocketMQSqlUtils.makePullConsumer(groupId, options))
     }
 
     // If this is reattempt at running the task, then invalidate cache and start with
@@ -402,7 +402,7 @@ private object CachedRocketMQConsumer extends Logging {
     val groupId = options.get(RocketMQConf.CONSUMER_GROUP)
     val client = synchronized {
       groupIdUseCount.getOrElseUpdate(groupId, new MutableInt(0)).increment()
-      groupIdToClient.getOrElseUpdate(groupId, RocketMQUtils.makePullConsumer(groupId, options))
+      groupIdToClient.getOrElseUpdate(groupId, RocketMQSqlUtils.makePullConsumer(groupId, options))
     }
 
     new CachedRocketMQConsumer(client, queue, options)

--- a/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/CachedRocketMQProducer.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/CachedRocketMQProducer.scala
@@ -69,7 +69,7 @@ private[rocketmq] object CachedRocketMQProducer extends Logging {
     try {
       guavaCache.get(group, new Callable[Producer] {
         override def call(): Producer = {
-          val producer = RocketMQUtils.makeProducer(group, options)
+          val producer = RocketMQSqlUtils.makeProducer(group, options)
           logDebug(s"Created a new instance of RocketMQ producer for group $group.")
           producer
         }

--- a/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/RocketMQOffsetReader.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/RocketMQOffsetReader.scala
@@ -218,7 +218,7 @@ private class RocketMQOffsetReader(
   private def createConsumer(): MQPullConsumer = synchronized {
     val newRocketMQParams = new ju.HashMap[String, String](driverRocketMQParams)
     val groupId = nextGroupId()
-    RocketMQUtils.makePullConsumer(groupId, newRocketMQParams)
+    RocketMQSqlUtils.makePullConsumer(groupId, newRocketMQParams)
   }
 
   private def resetConsumer(): Unit = synchronized {

--- a/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/RocketMQSqlUtils.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/RocketMQSqlUtils.scala
@@ -24,7 +24,7 @@ import org.apache.rocketmq.client.producer.DefaultMQProducer
 /**
  * Some helper methods of RocketMQ
  */
-object RocketMQUtils {
+object RocketMQSqlUtils {
 
   def makePullConsumer(groupId: String, optionParams: ju.Map[String, String]): DefaultMQPullConsumer = {
     val consumer = new DefaultMQPullConsumer(groupId)

--- a/rocketmq-spark/src/main/scala/org/apache/spark/streaming/MQPullInputDStream.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/streaming/MQPullInputDStream.scala
@@ -20,11 +20,11 @@ package org.apache.spark.streaming
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
 import java.{lang => jl, util => ju}
-
 import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer
 import org.apache.rocketmq.client.consumer.store.ReadOffsetType
 import org.apache.rocketmq.common.MixAll
 import org.apache.rocketmq.common.message.{MessageExt, MessageQueue}
+import org.apache.rocketmq.spark.streaming.MQPullConsumerProvider
 import org.apache.rocketmq.spark.{ConsumerStrategy, _}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.dstream.{DStream, DStreamCheckpointData, InputDStream}
@@ -64,7 +64,7 @@ class MQPullInputDStream(
     autoCommit: Boolean,
     forceSpecial: Boolean,
     failOnDataLoss: Boolean
-  ) extends InputDStream[MessageExt](_ssc) with CanCommitOffsets{
+  ) extends InputDStream[MessageExt](_ssc) with CanCommitOffsets {
 
   private var currentOffsets = mutable.Map[TopicQueueId, Map[String, Long]]()
 
@@ -75,7 +75,7 @@ class MQPullInputDStream(
   private val maxRateLimitPerPartition = optionParams.getOrDefault(RocketMQConfig.MAX_PULL_SPEED_PER_PARTITION,
     "-1").toInt
   
-  @transient private var kc: DefaultMQPullConsumer = null
+  @transient private var kc: MQPullConsumerProvider = null
 
   /**
     * start up timer thread to persis the OffsetStore

--- a/rocketmq-spark/src/main/scala/org/apache/spark/streaming/MQPullInputDStream.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/streaming/MQPullInputDStream.scala
@@ -414,7 +414,7 @@ class MQPullInputDStream(
         uo.map { case (name, until) =>
           val offset = currentOffsets(tp)(name) - 1
           val mq = new MessageQueue(tp.topic, name, tp.queueId)
-          kc.updateConsumeOffset(mq, offset)
+          kc.commitConsumeOffset(mq, offset)
         }
       }
     } else {
@@ -460,7 +460,7 @@ class MQPullInputDStream(
       while (null != osr) {
         //Exclusive ending offset
         val mq = new MessageQueue(osr.topic, osr.brokerName, osr.queueId)
-        kc.updateConsumeOffset(mq, osr.untilOffset - 1)
+        kc.commitConsumeOffset(mq, osr.untilOffset - 1)
         m.put(mq, osr.untilOffset - 1)
         osr = commitQueue.poll()
       }

--- a/rocketmq-spark/src/main/scala/org/apache/spark/streaming/MQPullInputDStream.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/streaming/MQPullInputDStream.scala
@@ -101,6 +101,7 @@ class MQPullInputDStream(
         }
       }
 
+      // TODO should not persist here if autoCommit is off
       // timer persist
       this.scheduledExecutorService.scheduleAtFixedRate(
         new Runnable() {

--- a/rocketmq-spark/src/main/scala/org/apache/spark/streaming/RocketMqRDD.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/streaming/RocketMqRDD.scala
@@ -47,7 +47,7 @@ class RocketMqRDD (
       val offsetRanges: ju.Map[TopicQueueId, Array[OffsetRange]],
       val preferredHosts: ju.Map[TopicQueueId, String],
       val useConsumerCache: Boolean
-    )extends RDD[MessageExt](sc, Nil) with HasOffsetRanges{
+    ) extends RDD[MessageExt](sc, Nil) with HasOffsetRanges {
 
   private val cacheInitialCapacity =
     optionParams.getOrDefault(RocketMQConfig.PULL_CONSUMER_CACHE_INIT_CAPACITY, "16").toInt

--- a/rocketmq-spark/src/test/java/org/apache/rocketmq/spark/sql/RocketMQDataSourceTest.java
+++ b/rocketmq-spark/src/test/java/org/apache/rocketmq/spark/sql/RocketMQDataSourceTest.java
@@ -19,9 +19,8 @@ package org.apache.rocketmq.spark.sql;
 
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
-import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
-import org.apache.rocketmq.client.consumer.PullResult;
-import org.apache.rocketmq.client.consumer.PullStatus;
+import org.apache.rocketmq.client.consumer.*;
+import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.spark.RocketMQServerMock;
 import org.apache.spark.sql.Dataset;
@@ -38,8 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
@@ -152,22 +150,22 @@ public class RocketMQDataSourceTest {
     }
 
     private static int checkTopicData(String topic) throws Exception {
-        DefaultMQPullConsumer consumer = new DefaultMQPullConsumer("test_consumer");
+        String subExpression = null;
+        DefaultLitePullConsumer consumer = new DefaultLitePullConsumer("test_consumer");
+        consumer.setNamesrvAddr(mockServer.getNameServerAddr());
+        consumer.subscribe(topic, subExpression);
         consumer.start();
 
         int messageCount = 0;
-        Set<MessageQueue> mqs = consumer.fetchSubscribeMessageQueues(topic);
-        for (MessageQueue mq : mqs) {
-            String subExpression = null;
-            PullResult pullResult = consumer.pull(mq, subExpression, 0, 1000);
-            if (pullResult.getPullStatus() == PullStatus.FOUND) {
-                for (int i = 0; i < pullResult.getMsgFoundList().size(); i++) {
-                    String messageBody = new String(pullResult.getMsgFoundList().get(i).getBody());
-                    logger.info("Got message: " + messageBody);
-                    assertEquals("\"Hello Rocket\"", messageBody.substring(0, 14));
-                    messageCount++;
-                }
+        List<MessageExt> result = consumer.poll();
+        while (result != null && !result.isEmpty()) {
+            for (int i = 0; i < result.size(); i++) {
+                String messageBody = new String(result.get(i).getBody());
+                logger.info("Got message: " + messageBody);
+                assertEquals("\"Hello Rocket\"", messageBody.substring(0, 14));
+                messageCount++;
             }
+            result = consumer.poll();
         }
 
         consumer.shutdown();

--- a/rocketmq-spark/src/test/java/org/apache/rocketmq/spark/sql/RocketMQDataSourceTest.java
+++ b/rocketmq-spark/src/test/java/org/apache/rocketmq/spark/sql/RocketMQDataSourceTest.java
@@ -158,7 +158,8 @@ public class RocketMQDataSourceTest {
         int messageCount = 0;
         Set<MessageQueue> mqs = consumer.fetchSubscribeMessageQueues(topic);
         for (MessageQueue mq : mqs) {
-            PullResult pullResult = consumer.pull(mq, null, 0, 1000);
+            String subExpression = null;
+            PullResult pullResult = consumer.pull(mq, subExpression, 0, 1000);
             if (pullResult.getPullStatus() == PullStatus.FOUND) {
                 for (int i = 0; i < pullResult.getMsgFoundList().size(); i++) {
                     String messageBody = new String(pullResult.getMsgFoundList().get(i).getBody());


### PR DESCRIPTION
## What is the purpose of the change

Here is some improvements about rocketmq-spark

## Brief changelog

1. Fix Checkstyle issues about the following class: `RocketMQConfig/MessageSet/DefaultMessageRetryManager/RocketMQReceiver`
2. Bump rocketmq client version from 4.2.0 to 4.9.4
3. Support custom pull consumer using SPI method with interface `MQPullConsumerProviderFactory/MQPullConsumerProvider`
4. Fix the issue about spark streaming job was still running when consumer client failed during start-up process
5. Improving documentation about direct stream and receiver stream



