### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/rocketmq-serializer/rocketmq-serializer-json/pom.xml
+++ b/rocketmq-serializer/rocketmq-serializer-json/pom.xml
@@ -14,10 +14,7 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.rocketmq</groupId>
@@ -35,7 +32,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <rocketmq.version>4.2.0</rocketmq.version>
         <commons-lang.version>2.5</commons-lang.version>
-        <fastjson.version>1.2.44</fastjson.version>
+        <fastjson.version>1.2.83</fastjson.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 6 security vulnerabilities found in com.alibaba:fastjson 1.2.44
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)
- [MPS-2019-28847](https://www.oscs1024.com/hd/MPS-2019-28847)
- [MPS-2019-28848](https://www.oscs1024.com/hd/MPS-2019-28848)
- [MPS-2020-39708](https://www.oscs1024.com/hd/MPS-2020-39708)
- [MPS-2020-40828](https://www.oscs1024.com/hd/MPS-2020-40828)
- [MPS-2018-27011](https://www.oscs1024.com/hd/MPS-2018-27011)


### What did I do？
Upgrade com.alibaba:fastjson from 1.2.44 to 1.2.83 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS