### PR TITLE
fix(sec): upgrade io.netty:netty-all to 4.1.44.Final

### DIFF
--- a/rocketmq-iot-bridge/pom.xml
+++ b/rocketmq-iot-bridge/pom.xml
@@ -14,9 +14,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.rocketmq</groupId>
@@ -29,7 +27,7 @@ limitations under the License.
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.26.Final</version>
+            <version>4.1.44.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
### What happened？
There are 4 security vulnerabilities found in io.netty:netty-all 4.1.26.Final
- [CVE-2019-16869](https://www.oscs1024.com/hd/CVE-2019-16869)
- [CVE-2020-7238](https://www.oscs1024.com/hd/CVE-2020-7238)
- [CVE-2019-20444](https://www.oscs1024.com/hd/CVE-2019-20444)
- [CVE-2019-20445](https://www.oscs1024.com/hd/CVE-2019-20445)


### What did I do？
Upgrade io.netty:netty-all from 4.1.26.Final to 4.1.44.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS