### PR TITLE
fix spark bug:Literal must have a corresponding value to string, but class String found. ChengJie1053 A minute ago

### DIFF
--- a/rocketmq-spark/pom.xml
+++ b/rocketmq-spark/pom.xml
@@ -34,9 +34,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <rocketmq.version>4.9.4</rocketmq.version>
-        <spark.version>2.3.0</spark.version>
-        <scala.version>2.11.8</scala.version>
-        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>3.3.1</spark.version>
+        <scala.version>2.12.10</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
         <commons-lang.version>2.5</commons-lang.version>
     </properties>
 

--- a/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/RocketMQSource.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/RocketMQSource.scala
@@ -115,7 +115,6 @@ private class RocketMQSource(
           if (content(0) == 'v') {
             val indexOfNewLine = content.indexOf("\n")
             if (indexOfNewLine > 0) {
-              val version = parseVersion(content.substring(0, indexOfNewLine), VERSION)
               RocketMQSourceOffset(SerializedOffset(content.substring(indexOfNewLine + 1)))
             } else {
               throw new IllegalStateException(

--- a/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/RocketMQSourceOffset.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/RocketMQSourceOffset.scala
@@ -25,15 +25,14 @@
 package org.apache.spark.sql.rocketmq
 
 import org.apache.rocketmq.common.message.MessageQueue
+import org.apache.spark.sql.connector.read.streaming.PartitionOffset
 import org.apache.spark.sql.execution.streaming.{Offset, SerializedOffset}
-import org.apache.spark.sql.sources.v2.reader.streaming.{PartitionOffset, Offset => OffsetV2}
-
 /**
  * An [[Offset]] for the [[RocketMQSource]]. This one tracks all partitions of subscribed topics and
  * their offsets.
  */
 private[rocketmq]
-case class RocketMQSourceOffset(queueToOffsets: Map[MessageQueue, Long]) extends OffsetV2 {
+case class RocketMQSourceOffset(queueToOffsets: Map[MessageQueue, Long]) extends Offset {
   override val json = JsonUtils.partitionOffsets(queueToOffsets)
 }
 

--- a/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/RocketMQSourceRDD.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/sql/rocketmq/RocketMQSourceRDD.scala
@@ -174,7 +174,7 @@ private[rocketmq] class RocketMQSourceRDD(
         }
       }
       // Release consumer, either by removing it or indicating we're no longer using it
-      context.addTaskCompletionListener { _ =>
+      context.addTaskCompletionListener[Unit] { _ =>
         underlying.closeIfNeeded()
       }
       underlying

--- a/rocketmq-spark/src/main/scala/org/apache/spark/streaming/RocketMqRDD.scala
+++ b/rocketmq-spark/src/main/scala/org/apache/spark/streaming/RocketMqRDD.scala
@@ -178,7 +178,7 @@ class RocketMqRDD (
     logDebug(s"Computing topic ${part.topic}, queueId ${part.queueId} " +
       s"offsets ${part.partitionOffsetRanges.mkString(",")}")
 
-    context.addTaskCompletionListener{ context => closeIfNeeded() }
+    context.addTaskCompletionListener[Unit]{ context => closeIfNeeded() }
 
 
     val consumer = if (useConsumerCache) {


### PR DESCRIPTION
fix spark bug:Literal must have a corresponding value to string, but class String found. ChengJie1053 A minute ago

Related issues: https://github.com/apache/rocketmq-externals/issues/910